### PR TITLE
Integrate full class database

### DIFF
--- a/class-data.js
+++ b/class-data.js
@@ -1,0 +1,199 @@
+(function(global){
+  const CLASS_DATABASE = [
+    { name:"Knight", stats:{STR:8,DEX:4,CON:8,INT:3,WIS:4,CHA:5}, attunement:{FAE:0,DREAM:0}, resources:{HP:35,EP:1,AP:2,MOV:3}, startingSkills:["Taunt","Shield Wall","Parry"] },
+    { name:"Magician", stats:{STR:3,DEX:5,CON:4,INT:8,WIS:6,CHA:4}, attunement:{FAE:6,DREAM:5}, resources:{HP:22,EP:1,AP:2,MOV:4}, startingSkills:["Arcane Bolt","Elemental Blast","Ward"] },
+    { name:"Warlock", stats:{STR:3,DEX:4,CON:4,INT:7,WIS:4,CHA:4}, attunement:{FAE:7,DREAM:7}, resources:{HP:20,EP:1,AP:2,MOV:4}, startingSkills:["Life Leech","Hex","Dark Pact"] },
+    { name:"Archer", stats:{STR:4,DEX:8,CON:5,INT:4,WIS:3,CHA:5}, attunement:{FAE:0,DREAM:0}, resources:{HP:24,EP:1,AP:2,MOV:6}, startingSkills:["Snipe","Volley","Pinning Shot"] },
+    { name:"Scout", stats:{STR:4,DEX:7,CON:4,INT:4,WIS:3,CHA:6}, attunement:{FAE:0,DREAM:0}, resources:{HP:22,EP:1,AP:2,MOV:7}, startingSkills:["Slipstream Step","Trap Sense","Ambush"] },
+    { name:"Cleric", stats:{STR:3,DEX:4,CON:5,INT:5,WIS:8,CHA:5}, attunement:{FAE:0,DREAM:2}, resources:{HP:26,EP:1,AP:2,MOV:4}, startingSkills:["Heal","Turn Undead","Ward Chant"] },
+    { name:"Druid", stats:{STR:3,DEX:4,CON:5,INT:6,WIS:7,CHA:4}, attunement:{FAE:6,DREAM:3}, resources:{HP:25,EP:1,AP:2,MOV:5}, startingSkills:["Shapeshift","Entangle","Restorative Wind"] },
+    { name:"Fighter", stats:{STR:7,DEX:6,CON:6,INT:4,WIS:4,CHA:4}, attunement:{FAE:0,DREAM:0}, resources:{HP:30,EP:1,AP:2,MOV:5}, startingSkills:["Power Strike","Counter","Weapon Stance"] },
+    { name:"Rogue", stats:{STR:5,DEX:8,CON:4,INT:4,WIS:3,CHA:6}, attunement:{FAE:0,DREAM:0}, resources:{HP:22,EP:1,AP:2,MOV:6}, startingSkills:["Backstab","Poisoned Dagger","Camouflage"] },
+    { name:"Monk", stats:{STR:6,DEX:7,CON:5,INT:4,WIS:6,CHA:4}, attunement:{FAE:0,DREAM:2}, resources:{HP:27,EP:1,AP:2,MOV:6}, startingSkills:["Counterstrike","Chi Strike","Palm of Flame"] },
+    { name:"Shaman", stats:{STR:4,DEX:4,CON:5,INT:5,WIS:7,CHA:4}, attunement:{FAE:2,DREAM:6}, resources:{HP:25,EP:1,AP:2,MOV:4}, startingSkills:["Totem Call","Spirit Bind","Stormsong"] },
+    { name:"Warden", stats:{STR:7,DEX:3,CON:9,INT:3,WIS:5,CHA:4}, attunement:{FAE:0,DREAM:0}, resources:{HP:38,EP:1,AP:2,MOV:3}, startingSkills:["Zone Control","Shield Slam","Fortify"] },
+    { name:"Engineer", stats:{STR:4,DEX:4,CON:6,INT:7,WIS:5,CHA:3}, attunement:{FAE:0,DREAM:0}, resources:{HP:28,EP:1,AP:2,MOV:4}, startingSkills:["Deploy Turret","Trap","Salvage Duty"] },
+    { name:"Necromancer", stats:{STR:3,DEX:4,CON:4,INT:8,WIS:4,CHA:3}, attunement:{FAE:0,DREAM:8}, resources:{HP:22,EP:1,AP:2,MOV:4}, startingSkills:["Raise Skeleton","Fear","Soul Drain"] },
+    { name:"Reaper", stats:{STR:6,DEX:7,CON:4,INT:5,WIS:4,CHA:3}, attunement:{FAE:0,DREAM:6}, resources:{HP:24,EP:1,AP:2,MOV:6}, startingSkills:["Shadow Strike","Harvest Soul","Fade Step"] },
+    { name:"Symphonist", stats:{STR:4,DEX:5,CON:5,INT:6,WIS:5,CHA:8}, attunement:{FAE:4,DREAM:4}, resources:{HP:26,EP:1,AP:2,MOV:5}, startingSkills:["Harmony Strike","Discordant Wave","Resonance"] },
+    { name:"Gunslinger", stats:{STR:5,DEX:8,CON:4,INT:4,WIS:3,CHA:5}, attunement:{FAE:0,DREAM:0}, resources:{HP:22,EP:1,AP:2,MOV:6}, startingSkills:["Trick Shot","Ricochet","Quickdraw"] },
+    { name:"Ninja", stats:{STR:5,DEX:9,CON:3,INT:4,WIS:3,CHA:4}, attunement:{FAE:4,DREAM:4}, resources:{HP:20,EP:1,AP:2,MOV:7}, startingSkills:["Smoke Vanish","Kunai Throw","Shadowstep"] },
+    { name:"Samurai", stats:{STR:7,DEX:6,CON:6,INT:4,WIS:6,CHA:4}, attunement:{FAE:0,DREAM:2}, resources:{HP:30,EP:1,AP:2,MOV:4}, startingSkills:["Iaido Strike","Discipline Stance","Resolve"] },
+    { name:"Pirate", stats:{STR:7,DEX:6,CON:5,INT:4,WIS:3,CHA:6}, attunement:{FAE:0,DREAM:0}, resources:{HP:28,EP:1,AP:2,MOV:5}, startingSkills:["Disarm","Broadside","Rally or Rum"] },
+    { name:"Brigadier", stats:{STR:6,DEX:5,CON:8,INT:4,WIS:4,CHA:7}, attunement:{FAE:0,DREAM:0}, resources:{HP:34,EP:1,AP:2,MOV:4}, startingSkills:["Charge","Formation Guard","Tactical Rally"] },
+    { name:"Privateer", stats:{STR:6,DEX:7,CON:5,INT:4,WIS:4,CHA:6}, attunement:{FAE:0,DREAM:0}, resources:{HP:27,EP:1,AP:2,MOV:5}, startingSkills:["Boarding Action","Morale Breaker","Naval Tactics"] },
+    { name:"Spellblade", stats:{STR:6,DEX:6,CON:5,INT:7,WIS:4,CHA:4}, attunement:{FAE:5,DREAM:2}, resources:{HP:28,EP:1,AP:2,MOV:5}, startingSkills:["Flameblade","Arcane Slash","Elemental Guard"] },
+    { name:"Skaldblade", stats:{STR:7,DEX:6,CON:6,INT:4,WIS:4,CHA:7}, attunement:{FAE:0,DREAM:0}, resources:{HP:30,EP:1,AP:2,MOV:5}, startingSkills:["Tempo Strike","Chant Rally","Momentum Slash"] },
+    { name:"Essentier", stats:{STR:5,DEX:5,CON:7,INT:7,WIS:4,CHA:3}, attunement:{FAE:0,DREAM:0}, resources:{HP:32,EP:1,AP:2,MOV:4}, startingSkills:["Alchemy Strike","Scrap Bomb","Essence Burn"] },
+    { name:"Shadowguard", stats:{STR:6,DEX:7,CON:6,INT:4,WIS:4,CHA:4}, attunement:{FAE:0,DREAM:3}, resources:{HP:30,EP:1,AP:2,MOV:5}, startingSkills:["Swap Places","Intercept","Silent Guard"] },
+    { name:"Torchbearer", stats:{STR:7,DEX:5,CON:6,INT:4,WIS:4,CHA:4}, attunement:{FAE:6,DREAM:0}, resources:{HP:29,EP:1,AP:2,MOV:5}, startingSkills:["Ignite","Reveal Shadows","Firebrand"] },
+    { name:"Swashbuckler", stats:{STR:6,DEX:8,CON:5,INT:4,WIS:3,CHA:6}, attunement:{FAE:0,DREAM:0}, resources:{HP:28,EP:1,AP:2,MOV:6}, startingSkills:["Taunt","Parry-Riposte","Showboat"] },
+    { name:"Riftwarden", stats:{STR:5,DEX:5,CON:6,INT:6,WIS:7,CHA:4}, attunement:{FAE:0,DREAM:8}, resources:{HP:28,EP:1,AP:2,MOV:5}, startingSkills:["Teleport Rift","Banish","Anchor Zone"] },
+  ];
+
+  const SKILL_BEHAVIORS = {
+    "Taunt":"buffSelfGuard",
+    "Shield Wall":"buffSelfGuard",
+    "Parry":"buffSelfGuard",
+    "Arcane Bolt":"attackRanged",
+    "Elemental Blast":"attackRanged",
+    "Ward":"buffAllyGuard",
+    "Life Leech":"attackLifeSteal",
+    "Hex":"attackRanged",
+    "Dark Pact":"buffSelfInspire",
+    "Snipe":"attackRanged",
+    "Volley":"attackRanged",
+    "Pinning Shot":"attackRangedRoot",
+    "Slipstream Step":"buffSelfInspire",
+    "Trap Sense":"buffSelfGuard",
+    "Ambush":"attackMelee",
+    "Heal":"heal",
+    "Turn Undead":"attackRanged",
+    "Ward Chant":"buffAllyGuard",
+    "Shapeshift":"buffSelfInspire",
+    "Entangle":"root",
+    "Restorative Wind":"heal",
+    "Counter":"buffSelfGuard",
+    "Weapon Stance":"buffSelfInspire",
+    "Backstab":"attackMelee",
+    "Poisoned Dagger":"attackMeleeBleed",
+    "Camouflage":"buffSelfGuard",
+    "Counterstrike":"buffSelfGuard",
+    "Chi Strike":"attackMelee",
+    "Palm of Flame":"attackMelee",
+    "Totem Call":"buffAllyInspire",
+    "Spirit Bind":"attackLifeSteal",
+    "Stormsong":"attackRanged",
+    "Zone Control":"buffSelfGuard",
+    "Shield Slam":"attackMelee",
+    "Fortify":"buffAllyGuard",
+    "Deploy Turret":"attackRanged",
+    "Trap":"root",
+    "Salvage Duty":"heal",
+    "Raise Skeleton":"attackRanged",
+    "Fear":"attackRanged",
+    "Soul Drain":"attackLifeSteal",
+    "Shadow Strike":"attackMelee",
+    "Harvest Soul":"attackLifeSteal",
+    "Fade Step":"buffSelfInspire",
+    "Harmony Strike":"attackMelee",
+    "Discordant Wave":"attackRanged",
+    "Resonance":"heal",
+    "Trick Shot":"attackRanged",
+    "Ricochet":"attackRanged",
+    "Quickdraw":"attackRanged",
+    "Smoke Vanish":"buffSelfGuard",
+    "Kunai Throw":"attackRanged",
+    "Shadowstep":"buffSelfInspire",
+    "Iaido Strike":"attackMelee",
+    "Discipline Stance":"buffSelfGuard",
+    "Resolve":"buffSelfGuard",
+    "Disarm":"attackMelee",
+    "Broadside":"attackRanged",
+    "Rally or Rum":"heal",
+    "Charge":"attackMelee",
+    "Formation Guard":"buffAllyGuard",
+    "Tactical Rally":"buffAllyInspire",
+    "Boarding Action":"attackMelee",
+    "Morale Breaker":"attackMelee",
+    "Naval Tactics":"buffAllyInspire",
+    "Flameblade":"attackMelee",
+    "Arcane Slash":"attackMelee",
+    "Elemental Guard":"buffSelfGuard",
+    "Tempo Strike":"attackMelee",
+    "Chant Rally":"buffAllyInspire",
+    "Momentum Slash":"attackMelee",
+    "Alchemy Strike":"attackMelee",
+    "Scrap Bomb":"attackRanged",
+    "Essence Burn":"attackRanged",
+    "Swap Places":"swap",
+    "Intercept":"buffAllyGuard",
+    "Silent Guard":"buffSelfGuard",
+    "Ignite":"attackRanged",
+    "Reveal Shadows":"buffAllyGuard",
+    "Firebrand":"attackMelee",
+    "Parry-Riposte":"attackMelee",
+    "Showboat":"buffSelfInspire",
+    "Teleport Rift":"buffSelfInspire",
+    "Banish":"attackRanged",
+    "Anchor Zone":"buffAllyGuard"
+  };
+
+  const DEFAULT_NAME_OVERRIDES = {
+    Knight:"Tallis (Knight)",
+    Archer:"Clover (Archer)"
+  };
+
+  const GLYPH_OVERRIDES = {
+    Knight:"⚔",
+    Magician:"✨",
+    Warlock:"☠",
+    Archer:"🏹",
+    Scout:"🧭",
+    Cleric:"✚",
+    Druid:"🌿",
+    Fighter:"🥊",
+    Rogue:"🗡",
+    Monk:"🙏",
+    Shaman:"🌀",
+    Warden:"🛡",
+    Engineer:"⚙",
+    Necromancer:"💀",
+    Reaper:"⚰",
+    Symphonist:"🎵",
+    Gunslinger:"🔫",
+    Ninja:"🥷",
+    Samurai:"🥋",
+    Pirate:"🏴‍☠️",
+    Brigadier:"🎖",
+    Privateer:"⚓",
+    Spellblade:"✨",
+    Skaldblade:"🪕",
+    Essentier:"⚗️",
+    Shadowguard:"🌑",
+    Torchbearer:"🔥",
+    Swashbuckler:"🏴",
+    Riftwarden:"🌌"
+  };
+
+  function skillKey(name){
+    return name
+      .split(/[^a-zA-Z0-9]+/)
+      .filter(Boolean)
+      .map(part=>part.charAt(0).toUpperCase()+part.slice(1).toLowerCase())
+      .join('');
+  }
+
+  function defaultNameFor(name){
+    return DEFAULT_NAME_OVERRIDES[name] || name;
+  }
+
+  function inferRange(entry){
+    const rangedRegex = /(Shot|Throw|Bolt|Blast|Gun|Rift|Banish|Kunai|Ricochet|Quickdraw|Broadside|Volley|Snipe|Song|Wave|Wind|Bomb|Ignite|Essence|Spirit|Storm|Anchor|Teleport)/i;
+    if(entry.startingSkills.some(skill=>rangedRegex.test(skill))) return 3;
+    if(/Magician|Warlock|Cleric|Druid|Shaman|Necromancer|Reaper|Symphonist|Gunslinger|Ninja|Spellblade|Torchbearer|Riftwarden|Engineer|Archer|Scout|Privateer|Pirate/i.test(entry.name)) return 3;
+    if(entry.stats.DEX >= 8 || entry.stats.INT >= 7) return 2;
+    return 1;
+  }
+
+  function computeDerivedStats(entry){
+    const { stats, resources, attunement } = entry;
+    const maxHp = Math.max(18, Math.round((resources.HP || 20) * 1.5));
+    const atk = Math.max(6, Math.round(4 + stats.STR*0.9 + stats.INT*0.45 + stats.DEX*0.35));
+    const def = Math.max(4, Math.round(2 + stats.CON*0.9 + stats.WIS*0.35));
+    const dream = attunement && typeof attunement.DREAM === 'number' ? attunement.DREAM : 0;
+    const spd = Math.max(5, Math.round(3 + stats.DEX*1.05 + dream*0.35));
+    const range = inferRange(entry);
+    return { maxHp, atk, def, spd, range };
+  }
+
+  global.FABLE_DATA = {
+    CLASS_DATABASE,
+    SKILL_BEHAVIORS,
+    GLYPH_OVERRIDES,
+    defaultNameFor,
+    skillKey,
+    inferRange,
+    computeDerivedStats
+  };
+})(window);

--- a/index.html
+++ b/index.html
@@ -580,8 +580,11 @@
     </section>
   </main>
 
+<script src="class-data.js"></script>
 <script>
 /* Embedded sprite URIs or URLs. Replace with your own files if you like. */
+const CLASS_ENTRIES = window.FABLE_DATA.CLASS_DATABASE;
+const CLASS_NAMES = CLASS_ENTRIES.map(entry=>entry.name);
 const SPRITES = (()=>{
   const spriteSvg = (label, primary, accent, glyph)=>{
     const id = label.replace(/[^a-z0-9]/gi,'');
@@ -607,19 +610,24 @@ const SPRITES = (()=>{
     </svg>`;
     return `data:image/svg+xml;utf8,${encodeURIComponent(svg)}`;
   };
-  return {
-    Knight: spriteSvg('Knight','#3b6bff','#91b4ff','⚔'),
-    Fighter: spriteSvg('Fighter','#f97316','#facc15','🥊'),
-    Rogue: spriteSvg('Rogue','#0f766e','#22d3ee','🗡'),
-    Archer: spriteSvg('Archer','#2dd4bf','#60a5fa','🏹'),
-    Bruiser: spriteSvg('Bruiser','#f87171','#fb7185','💥'),
-    Imp: spriteSvg('Imp','#fb923c','#ef4444','🔥'),
-    Cleric: spriteSvg('Cleric','#a855f7','#f0abfc','✚'),
-    Bard: spriteSvg('Bard','#f472b6','#facc15','🎵'),
-    Druid: spriteSvg('Druid','#22c55e','#86efac','🌿'),
-    Enchanter: spriteSvg('Enchanter','#6366f1','#a855f7','✨'),
-    Shaman: spriteSvg('Shaman','#0ea5e9','#38bdf8','🌀'),
-  };
+  const palettes = [
+    ['#3b6bff','#91b4ff'],
+    ['#f97316','#facc15'],
+    ['#14b8a6','#60a5fa'],
+    ['#f472b6','#c084fc'],
+    ['#22c55e','#a3e635'],
+    ['#f87171','#fb7185'],
+    ['#0ea5e9','#38bdf8'],
+    ['#ef4444','#f97316'],
+    ['#a855f7','#f0abfc'],
+    ['#eab308','#f97316']
+  ];
+  const glyphs = window.FABLE_DATA.GLYPH_OVERRIDES || {};
+  return Object.fromEntries(CLASS_NAMES.map((label, idx)=>{
+    const [primary, accent] = palettes[idx % palettes.length];
+    const glyph = glyphs[label] || label[0] || '?';
+    return [label, spriteSvg(label, primary, accent, glyph)];
+  }));
 })();
 
 /* ========= Core / Grid ========= */
@@ -706,21 +714,167 @@ const AbilityLib={
     use(user,target,log){addStatus(target,"Root",log);log(`${user.name} roots ${target.name} in place!`);} },
 };
 
-/* ========= Templates ========= */
-const UnitTemplates = {
-  Knight:{ label:"Knight", name:"Tallis (Knight)", stats:{maxHp:60,atk:14,def:10,spd:7}, abilities:["PowerStrike","Guard"], range:1 },
-  Fighter:{ label:"Fighter", name:"Fighter", stats:{maxHp:54,atk:13,def:9, spd:9}, abilities:["PowerStrike","Guard"], range:1 },
-  Rogue:{ label:"Rogue", name:"Rogue", stats:{maxHp:42,atk:12,def:6, spd:13}, abilities:["PowerStrike","Guard"], range:1 },
-  Archer:{ label:"Archer", name:"Clover (Archer)", stats:{maxHp:44,atk:11,def:7, spd:12}, abilities:["BleedingShot","Recover"], range:3 },
-  Bruiser:{ label:"Bruiser", name:"Goblin Bruiser", stats:{maxHp:40,atk:12,def:6, spd:8}, abilities:["PowerStrike"], range:1 },
-  Imp:{ label:"Imp", name:"Woad Imp", stats:{maxHp:32,atk:9, def:5, spd:11}, abilities:["BleedingShot"], range:3 },
+const SKILL_BEHAVIORS = window.FABLE_DATA.SKILL_BEHAVIORS;
+const skillKey = window.FABLE_DATA.skillKey;
 
-  Cleric:{ label:"Cleric", name:"Cleric", stats:{maxHp:46,atk:9, def:8, spd:9}, abilities:["Heal","Shield"], range:3 },
-  Bard:{ label:"Bard", name:"Bard", stats:{maxHp:42,atk:9, def:7, spd:12}, abilities:["Inspire","Recover"], range:3 },
-  Druid:{ label:"Druid", name:"Druid", stats:{maxHp:44,atk:10,def:7, spd:10}, abilities:["Root","Heal"], range:3 },
-  Enchanter:{ label:"Enchanter", name:"Enchanter", stats:{maxHp:38,atk:10,def:6, spd:11}, abilities:["Shield","Inspire"], range:3 },
-  Shaman:{ label:"Shaman", name:"Shaman", stats:{maxHp:44,atk:11,def:7, spd:10}, abilities:["Heal","Inspire"], range:3 },
-};
+function ensureAbilityForSkill(name){
+  const key = skillKey(name);
+  if(AbilityLib[key]) return key;
+  const behavior = SKILL_BEHAVIORS[name] || 'attackMelee';
+  AbilityLib[key] = makeAbilityFromBehavior(name, behavior);
+  return key;
+}
+
+function makeAbilityFromBehavior(name, behavior){
+  switch(behavior){
+    case 'attackRanged':
+      return {
+        name,
+        desc: `${name}: Ranged strike.`,
+        cooldown:1, range:3, target:'enemy',
+        use(user,target,log){
+          const atk = effAtk(user);
+          const dmg = computeDamage(atk, effDef(target));
+          applyDamage(target,dmg,log,`${user.name} uses ${name} on ${target.name} for <span class=\"dmg\">-${dmg}</span>.`);
+        }
+      };
+    case 'attackRangedRoot':
+      return {
+        name,
+        desc: `${name}: Ranged strike that roots.`,
+        cooldown:2, range:3, target:'enemy',
+        use(user,target,log){
+          const atk = effAtk(user);
+          const dmg = computeDamage(atk, effDef(target));
+          applyDamage(target,dmg,log,`${user.name} uses ${name} on ${target.name} for <span class=\"dmg\">-${dmg}</span>.`);
+          if(!target.dead){ addStatus(target,'Root',log); log(`${target.name} is rooted by ${name}.`); }
+        }
+      };
+    case 'attackMeleeBleed':
+      return {
+        name,
+        desc: `${name}: Close strike that bleeds.`,
+        cooldown:2, range:1, target:'enemy',
+        use(user,target,log){
+          const atk = effAtk(user);
+          const dmg = computeDamage(atk, effDef(target));
+          applyDamage(target,dmg,log,`${user.name} uses ${name} on ${target.name} for <span class=\"dmg\">-${dmg}</span>.`);
+          if(!target.dead){ addStatus(target,'Bleed',log); log(`${target.name} bleeds from ${name}.`); }
+        }
+      };
+    case 'attackLifeSteal':
+      return {
+        name,
+        desc: `${name}: Strike and siphon life.`,
+        cooldown:2, range:2, target:'enemy',
+        use(user,target,log){
+          const atk = effAtk(user);
+          const dmg = computeDamage(atk, effDef(target));
+          applyDamage(target,dmg,log,`${user.name} uses ${name} on ${target.name} for <span class=\"dmg\">-${dmg}</span>.`);
+          if(dmg>0 && !user.dead){
+            const before = user.hp;
+            user.hp = clamp(user.hp + Math.ceil(dmg/2), 0, user.stats.maxHp);
+            const healed = user.hp - before;
+            if(healed>0){ log(`${user.name} siphons <span class=\"heal\">+${healed}</span> HP.`); }
+          }
+        }
+      };
+    case 'buffSelfGuard':
+      return {
+        name,
+        desc: `${name}: Brace for impact.`,
+        cooldown:2, range:0, target:'self',
+        use(user,_target,log){ addStatus(user,'Guard',log); log(`${user.name} uses ${name} and steadies their defense.`); }
+      };
+    case 'buffSelfInspire':
+      return {
+        name,
+        desc: `${name}: Empower self.`,
+        cooldown:2, range:0, target:'self',
+        use(user,_target,log){ addStatus(user,'Inspire',log); log(`${user.name} channels ${name}.`); }
+      };
+    case 'buffAllyGuard':
+      return {
+        name,
+        desc: `${name}: Protect an ally.`,
+        cooldown:2, range:3, target:'ally',
+        use(user,target,log){ addStatus(target,'Guard',log); log(`${user.name} uses ${name} to shield ${target.name}.`); }
+      };
+    case 'buffAllyInspire':
+      return {
+        name,
+        desc: `${name}: Bolster an ally.`,
+        cooldown:2, range:3, target:'ally',
+        use(user,target,log){ addStatus(target,'Inspire',log); log(`${user.name} inspires ${target.name} with ${name}.`); }
+      };
+    case 'heal':
+      return {
+        name,
+        desc: `${name}: Restore an ally.`,
+        cooldown:2, range:3, target:'ally',
+        use(user,target,log){
+          const before = target.hp;
+          target.hp = clamp(target.hp + 18, 0, target.stats.maxHp);
+          const healed = target.hp - before;
+          log(`${user.name} uses ${name} on ${target.name} for <span class=\"heal\">+${healed}</span> HP.`);
+        }
+      };
+    case 'root':
+      return {
+        name,
+        desc: `${name}: Immobilize an enemy.`,
+        cooldown:2, range:3, target:'enemy',
+        use(user,target,log){ addStatus(target,'Root',log); log(`${user.name} uses ${name} to root ${target.name}.`); }
+      };
+    case 'swap':
+      return {
+        name,
+        desc: `${name}: Swap positions with an ally.`,
+        cooldown:2, range:3, target:'ally',
+        use(user,target,log){
+          if(user===target) return;
+          if(!user.pos || !target.pos){ log(`${name} fizzles; both units must be placed.`); return; }
+          const ux = user.pos.x, uy = user.pos.y;
+          user.pos.x = target.pos.x;
+          user.pos.y = target.pos.y;
+          target.pos.x = ux;
+          target.pos.y = uy;
+          log(`${user.name} swaps places with ${target.name} using ${name}.`);
+        }
+      };
+    case 'attackMelee':
+    default:
+      return {
+        name,
+        desc: `${name}: Close-range strike.`,
+        cooldown:1, range:1, target:'enemy',
+        use(user,target,log){
+          const atk = effAtk(user);
+          const dmg = computeDamage(atk, effDef(target));
+          applyDamage(target,dmg,log,`${user.name} uses ${name} on ${target.name} for <span class=\"dmg\">-${dmg}</span>.`);
+        }
+      };
+  }
+}
+
+/* ========= Templates ========= */
+const UnitTemplates = Object.fromEntries(CLASS_ENTRIES.map(entry=>{
+  const derived = window.FABLE_DATA.computeDerivedStats(entry);
+  const abilityKeys = (entry.startingSkills||[]).map(skill=>ensureAbilityForSkill(skill));
+  const abilities = abilityKeys.length ? abilityKeys : ['PowerStrike'];
+  return [entry.name, {
+    label: entry.name,
+    name: window.FABLE_DATA.defaultNameFor(entry.name),
+    stats:{ maxHp: derived.maxHp, atk: derived.atk, def: derived.def, spd: derived.spd },
+    abilities,
+    range: derived.range,
+    epMax: entry.resources?.EP ?? 2,
+    mov: entry.resources?.MOV ?? 4,
+    attributes: entry.stats,
+    attunement: entry.attunement,
+    resources: entry.resources
+  }];
+}));
 
 function makeUnit(tplKey, team, pos){
   const T = UnitTemplates[tplKey] || UnitTemplates.Knight;
@@ -729,10 +883,12 @@ function makeUnit(tplKey, team, pos){
     name: T.name, team, tplKey,
     stats: {...T.stats}, hp:T.stats.maxHp, dead:false,
     temp:{defBonus:0,defend:false,atkBuff:0,spdBuff:0,shield:0}, statuses:[],
-    abilities: T.abilities.map(k=>({key:k,cd:0})),
-    range: T.range,
+    abilities: (T.abilities||[]).map(k=>({key:k,cd:0})),
+    range: T.range ?? 1,
     pos: pos? {...pos} : null,
-    ep: 0, epMax: 2
+    ep: 0, epMax: T.epMax ?? 2,
+    mov: T.mov ?? 4,
+    dataset: T
   };
 }
 
@@ -1107,9 +1263,9 @@ presetBtn.onclick=()=>{
   G.units.push(makeUnit("Archer","ally",{x:0,y:Math.min(GRID.h-1,midY+1)}));
   G.units.push(makeUnit("Cleric","ally",{x:0,y:Math.max(0,midY-1)}));
 
-  G.units.push(makeUnit("Bruiser","enemy",{x:GRID.w-1,y:midY}));
-  G.units.push(makeUnit("Imp","enemy",{x:GRID.w-1,y:Math.min(GRID.h-1,midY+1)}));
-  G.units.push(makeUnit("Druid","enemy",{x:GRID.w-1,y:Math.max(0,midY-1)}));
+  G.units.push(makeUnit("Warlock","enemy",{x:GRID.w-1,y:midY}));
+  G.units.push(makeUnit("Reaper","enemy",{x:GRID.w-1,y:Math.min(GRID.h-1,midY+1)}));
+  G.units.push(makeUnit("Shaman","enemy",{x:GRID.w-1,y:Math.max(0,midY-1)}));
   render();
 };
 clearBtn.onclick=()=>{ G.units=[]; render(); };

--- a/selector.html
+++ b/selector.html
@@ -212,6 +212,16 @@
     .meta .metaClass { color:#e0e8ff; font-weight:500; }
     .meta .pos { padding:2px 6px; border-radius:6px; background:rgba(24,32,52,.8); border:1px solid rgba(44,60,92,.6); font-size:11px; letter-spacing:.03em; }
     .pill { font-size:11px; padding:4px 8px; border-radius:999px; border:1px solid rgba(76,86,120,.8); background:rgba(16,23,41,.6); }
+    .classInfo {
+      margin-top:12px;
+      padding:12px;
+      border-radius:10px;
+      background:rgba(15,20,32,.78);
+      border:1px solid rgba(60,72,110,.7);
+      box-shadow:0 8px 16px rgba(0,0,0,.25) inset;
+      line-height:1.6;
+    }
+    .classInfo strong { color:#e5f0ff; }
   </style>
 </head>
 <body>
@@ -252,6 +262,7 @@
       <div class="sep"></div>
       <div class="small">Sprite preview</div>
       <div id="preview" class="sprite"></div>
+      <div id="classInfo" class="classInfo small"></div>
     </section>
 
     <section class="panel">
@@ -292,12 +303,10 @@
     </section>
   </main>
 
+<script src="class-data.js"></script>
 <script>
-/* Keep this in sync with the game's UnitTemplates keys */
-const CLASSES = [
-  "Knight","Fighter","Rogue","Archer","Bruiser","Imp",
-  "Cleric","Bard","Druid","Enchanter","Shaman"
-];
+const CLASS_ENTRIES = window.FABLE_DATA.CLASS_DATABASE;
+const CLASS_NAMES = CLASS_ENTRIES.map(entry=>entry.name);
 
 /* Sprite map (use your real paths if you have them) */
 const SPRITES = (()=>{
@@ -325,35 +334,29 @@ const SPRITES = (()=>{
     </svg>`;
     return `data:image/svg+xml;utf8,${encodeURIComponent(svg)}`;
   };
-  return {
-    Knight: spriteSvg('Knight','#3b6bff','#91b4ff','⚔'),
-    Fighter: spriteSvg('Fighter','#f97316','#facc15','🥊'),
-    Rogue: spriteSvg('Rogue','#0f766e','#22d3ee','🗡'),
-    Archer: spriteSvg('Archer','#2dd4bf','#60a5fa','🏹'),
-    Bruiser: spriteSvg('Bruiser','#f87171','#fb7185','💥'),
-    Imp: spriteSvg('Imp','#fb923c','#ef4444','🔥'),
-    Cleric: spriteSvg('Cleric','#a855f7','#f0abfc','✚'),
-    Bard: spriteSvg('Bard','#f472b6','#facc15','🎵'),
-    Druid: spriteSvg('Druid','#22c55e','#86efac','🌿'),
-    Enchanter: spriteSvg('Enchanter','#6366f1','#a855f7','✨'),
-    Shaman: spriteSvg('Shaman','#0ea5e9','#38bdf8','🌀'),
-  };
+  const palettes = [
+    ['#3b6bff','#91b4ff'],
+    ['#f97316','#facc15'],
+    ['#14b8a6','#60a5fa'],
+    ['#f472b6','#c084fc'],
+    ['#22c55e','#a3e635'],
+    ['#f87171','#fb7185'],
+    ['#0ea5e9','#38bdf8'],
+    ['#ef4444','#f97316'],
+    ['#a855f7','#f0abfc'],
+    ['#eab308','#f97316']
+  ];
+  const glyphs = window.FABLE_DATA.GLYPH_OVERRIDES || {};
+  return Object.fromEntries(CLASS_NAMES.map((label, idx)=>{
+    const [primary, accent] = palettes[idx % palettes.length];
+    const glyph = glyphs[label] || label[0] || '?';
+    return [label, spriteSvg(label, primary, accent, glyph)];
+  }));
 })();
 
-/* Reasonable default names if user leaves blank */
-const DEFAULT_NAMES = {
-  Knight: "Tallis (Knight)",
-  Fighter:"Fighter",
-  Rogue:"Rogue",
-  Archer:"Clover (Archer)",
-  Bruiser:"Goblin Bruiser",
-  Imp: "Woad Imp",
-  Cleric:"Cleric",
-  Bard:"Bard",
-  Druid:"Druid",
-  Enchanter:"Enchanter",
-  Shaman:"Shaman"
-};
+function defaultNameFor(cls){
+  return window.FABLE_DATA.defaultNameFor(cls);
+}
 
 const state = {
   gridW: 8,
@@ -370,6 +373,7 @@ const xInput = document.getElementById('xInput');
 const yInput = document.getElementById('yInput');
 const addBtn = document.getElementById('addBtn');
 const preview = document.getElementById('preview');
+const classInfo = document.getElementById('classInfo');
 
 const gridW = document.getElementById('gridW');
 const gridH = document.getElementById('gridH');
@@ -382,8 +386,8 @@ const enemyList = document.getElementById('enemyList');
 
 /* init */
 (function init(){
-  classSel.innerHTML = CLASSES.map(c=>`<option value="${c}">${c}</option>`).join('');
-  classSel.value = "Knight";
+  classSel.innerHTML = CLASS_NAMES.map(c=>`<option value="${c}">${c}</option>`).join('');
+  classSel.value = CLASS_NAMES[0] || "Knight";
   updatePreview();
   gridW.value = state.gridW; gridH.value = state.gridH;
   renderLists();
@@ -392,13 +396,30 @@ const enemyList = document.getElementById('enemyList');
 function updatePreview(){
   const c = classSel.value;
   preview.style.backgroundImage = `url("${SPRITES[c]||''}")`;
+  if(classInfo){
+    const entry = CLASS_ENTRIES.find(e=>e.name===c);
+    if(entry){
+      const core = entry.stats || {};
+      const attune = entry.attunement || {};
+      const res = entry.resources || {};
+      const skills = (entry.startingSkills||[]).join(', ');
+      classInfo.innerHTML = `
+        <div><strong>Core:</strong> STR ${core.STR} • DEX ${core.DEX} • CON ${core.CON} • INT ${core.INT} • WIS ${core.WIS} • CHA ${core.CHA}</div>
+        <div><strong>Attune:</strong> FAE ${attune.FAE ?? 0} • DREAM ${attune.DREAM ?? 0}</div>
+        <div><strong>Vitals:</strong> HP ${res.HP ?? '-'} • EP ${res.EP ?? '-'} • AP ${res.AP ?? '-'} • MOV ${res.MOV ?? '-'}</div>
+        <div><strong>Skills:</strong> ${skills}</div>
+      `;
+    } else {
+      classInfo.textContent = '';
+    }
+  }
 }
 classSel.addEventListener('change', updatePreview);
 
 /* Add unit */
 addBtn.onclick = ()=>{
   const tpl = classSel.value;
-  const name = (nameInput.value||"").trim() || DEFAULT_NAMES[tpl] || tpl;
+  const name = (nameInput.value||"").trim() || defaultNameFor(tpl);
   const team = teamSel.value;
   let pos = null;
 


### PR DESCRIPTION
## Summary
- add a shared class-data.js that describes every class, its attributes, and starting skills
- generate sprites, unit templates, and placeholder abilities from the shared data so the main game supports the full roster
- update the party selector to use the shared database, display class stats/skills, and refresh the default preset units

## Testing
- not run (HTML/JS changes only)


------
https://chatgpt.com/codex/tasks/task_e_68d4cc2281c08324855bddcbc890e3ba