### PR TITLE
Add skill mechanics metadata and integrate ability details

### DIFF
--- a/class-data.js
+++ b/class-data.js
@@ -119,6 +119,95 @@
     "Anchor Zone":"buffAllyGuard"
   };
 
+  const SKILL_MECHANICS = {
+    "Taunt":{type:"Command",ep:1,ap:1,range:"2 hex AoE",cooldown:2,effect:"Enemies in range must target the user.",synergy:["Morale","Control"]},
+    "Shield Wall":{type:"Defensive",ep:1,ap:1,range:"Self + Adjacent",cooldown:3,effect:"+50% CON and prevents knockback.",synergy:["Defense"]},
+    "Parry":{type:"Defensive",ep:1,ap:1,range:"Melee",cooldown:1,effect:"Negate the next melee hit and counter for half damage.",synergy:["Counter"]},
+    "Arcane Bolt":{type:"Offensive",ep:1,ap:1,range:"3 hex",cooldown:0,effect:"Deal INT ×1.2 arcane damage.",synergy:["Arcane"]},
+    "Elemental Blast":{type:"Offensive",ep:1,ap:2,range:"2 hex AoE",cooldown:3,effect:"Deal INT ×1.5 damage of a random element.",synergy:["Elemental"]},
+    "Ward":{type:"Support",ep:1,ap:1,range:"Adjacent Ally",cooldown:2,effect:"Grant +20% RES.",synergy:["Protection"]},
+    "Life Leech":{type:"Offensive",ep:1,ap:1,range:"2 hex",cooldown:2,effect:"Deal INT damage and heal for half dealt.",synergy:["Dark","Sustain"]},
+    "Hex":{type:"Debuff",ep:1,ap:1,range:"3 hex",cooldown:2,effect:"-2 STR and DEX for 2 turns.",synergy:["Curse"]},
+    "Dark Pact":{type:"Special",ep:1,ap:2,range:"Self",cooldown:4,effect:"Lose 5 HP to gain +2 INT for 2 turns.",synergy:["Dark","Pact"]},
+    "Snipe":{type:"Offensive",ep:1,ap:2,range:"6 hex",cooldown:2,effect:"Ranged attack that ignores 50% DEF.",synergy:["Ranged"]},
+    "Volley":{type:"Offensive",ep:1,ap:2,range:"Line 5 hex",cooldown:3,effect:"Line AoE that excels against 3+ targets.",synergy:["Ranged","AoE"]},
+    "Pinning Shot":{type:"Offensive",ep:1,ap:1,range:"4 hex",cooldown:2,effect:"Deal DEX damage and reduce MOV by 2.",synergy:["Control"]},
+    "Slipstream Step":{type:"Movement",ep:1,ap:1,range:"Self",cooldown:1,effect:"Move while ignoring zones of control.",synergy:["Mobility"]},
+    "Trap Sense":{type:"Passive",ep:0,ap:0,range:"2 hex",cooldown:null,effect:"Reveal nearby traps.",synergy:["Detection"]},
+    "Ambush":{type:"Offensive",ep:1,ap:1,range:"Melee",cooldown:0,effect:"Deal bonus damage if the target has not acted.",synergy:["Stealth","Critical"]},
+    "Heal":{type:"Support",ep:1,ap:1,range:"Adjacent Ally",cooldown:2,effect:"Restore WIS ×2 HP.",synergy:["Holy"]},
+    "Turn Undead":{type:"Offensive",ep:1,ap:2,range:"3 hex AoE",cooldown:3,effect:"Deal WIS ×1.5 damage to Undead.",synergy:["Holy","Anti-Undead"]},
+    "Ward Chant":{type:"Support",ep:1,ap:2,range:"2 hex AoE",cooldown:3,effect:"Allies become immune to debuffs for 1 turn.",synergy:["Holy","Chant"]},
+    "Shapeshift":{type:"Special",ep:1,ap:2,range:"Self",cooldown:5,effect:"Transform into wolf (+DEX) or bear (+STR).",synergy:["Nature"]},
+    "Entangle":{type:"Control",ep:1,ap:1,range:"3 hex",cooldown:2,effect:"Root the target; MOV becomes 0 for 1 turn.",synergy:["Nature","Root"]},
+    "Restorative Wind":{type:"Healing",ep:1,ap:2,range:"2 hex AoE",cooldown:3,effect:"Heal WIS ×1.2 HP and cure Fatigue.",synergy:["Wind"]},
+    "Power Strike":{type:"Offensive",ep:1,ap:1,range:"Melee",cooldown:0,effect:"Deal STR ×1.5 damage with a chance to stagger.",synergy:["Physical"]},
+    "Counter":{type:"Defensive",ep:1,ap:1,range:"Self",cooldown:1,effect:"Prepare to counter the next melee hit.",synergy:["Counter"]},
+    "Weapon Stance":{type:"Utility",ep:0,ap:0,range:"Self",cooldown:null,effect:"Toggle between +STR or +DEF stance.",synergy:["Stance"]},
+    "Backstab":{type:"Offensive",ep:1,ap:1,range:"Melee",cooldown:0,effect:"Deal bonus damage from behind.",synergy:["Stealth","Critical"]},
+    "Poisoned Dagger":{type:"Offensive",ep:1,ap:1,range:"Melee",cooldown:2,effect:"Deal STR damage and apply Poison for 3 turns.",synergy:["Poison"]},
+    "Camouflage":{type:"Stealth",ep:1,ap:1,range:"Self",cooldown:3,effect:"Become hidden until an enemy is adjacent.",synergy:["Stealth"]},
+    "Counterstrike":{type:"Defensive",ep:1,ap:1,range:"Self",cooldown:1,effect:"Reflect 50% of melee damage taken.",synergy:["Counter"]},
+    "Chi Strike":{type:"Offensive",ep:1,ap:1,range:"Melee",cooldown:0,effect:"Deal WIS damage and stun.",synergy:["Ki"]},
+    "Palm of Flame":{type:"Offensive",ep:1,ap:2,range:"Cone",cooldown:3,effect:"Fire cone damage that ignites terrain.",synergy:["Fire"]},
+    "Totem Call":{type:"Utility",ep:1,ap:2,range:"2 hex",cooldown:5,effect:"Summon a Spirit Totem that emits an aura.",synergy:["Spirit"]},
+    "Spirit Bind":{type:"Debuff",ep:1,ap:1,range:"3 hex",cooldown:3,effect:"Target loses 1 EP for 1 turn.",synergy:["Spirit"]},
+    "Stormsong":{type:"Offensive",ep:1,ap:2,range:"3 hex AoE",cooldown:3,effect:"Deal lightning damage and inflict Shock.",synergy:["Storm"]},
+    "Zone Control":{type:"Command",ep:1,ap:1,range:"2 hex aura",cooldown:2,effect:"Enemies moving in range trigger opportunity attacks.",synergy:["Control"]},
+    "Shield Slam":{type:"Offensive",ep:1,ap:1,range:"Melee",cooldown:2,effect:"Deal STR damage and stagger.",synergy:["Stun"]},
+    "Fortify":{type:"Defensive",ep:1,ap:1,range:"Self",cooldown:3,effect:"Gain +30% CON for 2 turns.",synergy:["Defense"]},
+    "Deploy Turret":{type:"Utility",ep:1,ap:2,range:"2 hex",cooldown:4,effect:"Summon a turret that fires DEX-based shots.",synergy:["Construct"]},
+    "Trap":{type:"Utility",ep:1,ap:1,range:"1 hex",cooldown:3,effect:"Place a snare that roots and deals damage.",synergy:["Trap"]},
+    "Salvage Duty":{type:"Utility",ep:0,ap:1,range:"Self",cooldown:null,effect:"Collect salvage for extra loot.",synergy:["Resource"]},
+    "Raise Skeleton":{type:"Summon",ep:1,ap:2,range:"Adjacent",cooldown:5,effect:"Summon an undead minion.",synergy:["Necro"]},
+    "Fear":{type:"Debuff",ep:1,ap:1,range:"3 hex AoE",cooldown:3,effect:"Reduce CHA and morale of enemies.",synergy:["Fear"]},
+    "Soul Drain":{type:"Offensive",ep:1,ap:1,range:"2 hex",cooldown:2,effect:"Deal INT damage and reduce WIS.",synergy:["Dark"]},
+    "Shadow Strike":{type:"Offensive",ep:1,ap:1,range:"Melee",cooldown:0,effect:"Deal DEX and DREAM damage.",synergy:["Shadow"]},
+    "Harvest Soul":{type:"Offensive",ep:1,ap:2,range:"Melee",cooldown:3,effect:"Deal STR ×1.5 damage and heal for the damage dealt.",synergy:["Dark"]},
+    "Fade Step":{type:"Movement",ep:1,ap:1,range:"3 hex",cooldown:2,effect:"Teleport to a shadow tile.",synergy:["Shadow"]},
+    "Harmony Strike":{type:"Offensive",ep:1,ap:1,range:"Melee",cooldown:0,effect:"Deal STR + CHA damage with bonus if an ally is nearby.",synergy:["Harmony"]},
+    "Discordant Wave":{type:"Offensive",ep:1,ap:2,range:"2 hex AoE",cooldown:3,effect:"Deal INT damage and inflict Confuse.",synergy:["Chaos"]},
+    "Resonance":{type:"Support",ep:1,ap:1,range:"Adjacent Ally",cooldown:2,effect:"Grant +10% damage for 1 turn.",synergy:["Song"]},
+    "Trick Shot":{type:"Offensive",ep:1,ap:1,range:"4 hex",cooldown:0,effect:"Ricochet to a second target.",synergy:["Ranged"]},
+    "Ricochet":{type:"Offensive",ep:1,ap:2,range:"Line 3 hex",cooldown:2,effect:"Hit up to three enemies in a line.",synergy:["Ranged"]},
+    "Quickdraw":{type:"Utility",ep:0,ap:0,range:"Self",cooldown:null,effect:"Always acts first.",synergy:["Speed"]},
+    "Smoke Vanish":{type:"Stealth",ep:1,ap:1,range:"Self",cooldown:2,effect:"Become hidden until your next attack.",synergy:["Stealth"]},
+    "Kunai Throw":{type:"Offensive",ep:1,ap:1,range:"3 hex",cooldown:0,effect:"Throw a kunai for DEX damage; apply Bleed on crit.",synergy:["Ranged"]},
+    "Shadowstep":{type:"Movement",ep:1,ap:1,range:"4 hex",cooldown:2,effect:"Teleport behind an enemy and gain a free strike.",synergy:["Shadow"]},
+    "Iaido Strike":{type:"Offensive",ep:1,ap:2,range:"Melee",cooldown:2,effect:"Perform a high-damage opening strike.",synergy:["Duel"]},
+    "Discipline Stance":{type:"Utility",ep:0,ap:0,range:"Self",cooldown:null,effect:"Toggle between +DEX or +STR.",synergy:["Stance"]},
+    "Resolve":{type:"Support",ep:1,ap:1,range:"Self",cooldown:3,effect:"Become immune to fear and charm.",synergy:["Spirit"]},
+    "Disarm":{type:"Offensive",ep:1,ap:1,range:"Melee",cooldown:2,effect:"Remove the target's weapon for 1 turn.",synergy:["Control"]},
+    "Broadside":{type:"Offensive",ep:1,ap:2,range:"Line 3 hex",cooldown:3,effect:"Deal STR damage in a line and knock back.",synergy:["AoE"]},
+    "Rally or Rum":{type:"Support",ep:1,ap:1,range:"2 hex AoE",cooldown:3,effect:"Boost morale and cure Fear.",synergy:["Morale"]},
+    "Charge":{type:"Offensive",ep:1,ap:2,range:"4 hex line",cooldown:3,effect:"Deal STR ×2 damage and knock back.",synergy:["Cavalry"]},
+    "Formation Guard":{type:"Defensive",ep:1,ap:1,range:"Adjacent Allies",cooldown:2,effect:"Grant +DEF to formation allies.",synergy:["Defense"]},
+    "Tactical Rally":{type:"Command",ep:1,ap:2,range:"2 hex AoE",cooldown:4,effect:"Allies gain +1 AP for the turn.",synergy:["Command"]},
+    "Boarding Action":{type:"Offensive",ep:1,ap:2,range:"2 hex",cooldown:3,effect:"Leap to target, deal STR damage, and disorient.",synergy:["Pirate"]},
+    "Morale Breaker":{type:"Debuff",ep:1,ap:1,range:"2 hex AoE",cooldown:3,effect:"Lower CHA and morale of enemies.",synergy:["Morale"]},
+    "Naval Tactics":{type:"Passive",ep:0,ap:0,range:"Self",cooldown:null,effect:"Ignore movement penalties from water.",synergy:["Movement"]},
+    "Flameblade":{type:"Offensive",ep:1,ap:1,range:"Melee",cooldown:0,effect:"Imbue weapon with fire for 2 turns.",synergy:["Fire"]},
+    "Arcane Slash":{type:"Offensive",ep:1,ap:1,range:"Melee",cooldown:2,effect:"Deal INT damage and knock back.",synergy:["Arcane"]},
+    "Elemental Guard":{type:"Defensive",ep:1,ap:1,range:"Self",cooldown:3,effect:"Resist fire, ice, and lightning.",synergy:["Elemental"]},
+    "Tempo Strike":{type:"Offensive",ep:1,ap:1,range:"Melee",cooldown:0,effect:"Deal STR damage with bonus if a Bard or Dancer is nearby.",synergy:["Rhythm"]},
+    "Chant Rally":{type:"Support",ep:1,ap:2,range:"2 hex AoE",cooldown:3,effect:"Raise morale and damage for allies.",synergy:["Chant"]},
+    "Momentum Slash":{type:"Offensive",ep:1,ap:2,range:"3 hex line",cooldown:3,effect:"Damage scales with attacks this round.",synergy:["Combo"]},
+    "Alchemy Strike":{type:"Offensive",ep:1,ap:1,range:"Melee",cooldown:0,effect:"Deal random elemental damage.",synergy:["Alchemy"]},
+    "Scrap Bomb":{type:"Offensive",ep:1,ap:2,range:"2 hex AoE",cooldown:3,effect:"Explosive AoE that leaves a salvage tile.",synergy:["Alchemy"]},
+    "Essence Burn":{type:"Debuff",ep:1,ap:1,range:"3 hex",cooldown:2,effect:"Reduce INT and FAE for 2 turns.",synergy:["Alchemy"]},
+    "Swap Places":{type:"Utility",ep:1,ap:1,range:"2 hex",cooldown:2,effect:"Swap positions with an ally.",synergy:["Position"]},
+    "Intercept":{type:"Defensive",ep:1,ap:1,range:"2 hex",cooldown:2,effect:"Take damage in place of an ally.",synergy:["Guard"]},
+    "Silent Guard":{type:"Stealth",ep:1,ap:1,range:"Self",cooldown:3,effect:"Become hidden and gain DEF.",synergy:["Stealth"]},
+    "Ignite":{type:"Offensive",ep:1,ap:1,range:"2 hex",cooldown:2,effect:"Deal fire damage and apply Burn.",synergy:["Fire"]},
+    "Reveal Shadows":{type:"Utility",ep:0,ap:0,range:"3 hex AoE",cooldown:null,effect:"Reveal hidden units in the area.",synergy:["Reveal"]},
+    "Firebrand":{type:"Offensive",ep:1,ap:2,range:"Cone",cooldown:3,effect:"Fire AoE that ignites terrain.",synergy:["Fire"]},
+    "Parry-Riposte":{type:"Offensive",ep:1,ap:1,range:"Melee",cooldown:1,effect:"Block a hit and retaliate instantly.",synergy:["Duel"]},
+    "Showboat":{type:"Support",ep:0,ap:1,range:"Self",cooldown:3,effect:"Boost self morale while lowering nearby enemies'.",synergy:["Performance"]},
+    "Teleport Rift":{type:"Movement",ep:1,ap:2,range:"5 hex",cooldown:3,effect:"Teleport an ally or self.",synergy:["Rift"]},
+    "Banish":{type:"Control",ep:1,ap:2,range:"3 hex",cooldown:3,effect:"Remove the target from the field for 1 turn.",synergy:["Rift"]},
+    "Anchor Zone":{type:"Defensive",ep:1,ap:1,range:"2 hex AoE",cooldown:4,effect:"Block teleport or blink within the zone.",synergy:["Rift"]}
+  };
+
   const DEFAULT_NAME_OVERRIDES = {
     Knight:"Tallis (Knight)",
     Archer:"Clover (Archer)"
@@ -168,6 +257,10 @@
     return DEFAULT_NAME_OVERRIDES[name] || name;
   }
 
+  function mechanicsForSkill(name){
+    return SKILL_MECHANICS[name] || null;
+  }
+
   function inferRange(entry){
     const rangedRegex = /(Shot|Throw|Bolt|Blast|Gun|Rift|Banish|Kunai|Ricochet|Quickdraw|Broadside|Volley|Snipe|Song|Wave|Wind|Bomb|Ignite|Essence|Spirit|Storm|Anchor|Teleport)/i;
     if(entry.startingSkills.some(skill=>rangedRegex.test(skill))) return 3;
@@ -190,10 +283,12 @@
   global.FABLE_DATA = {
     CLASS_DATABASE,
     SKILL_BEHAVIORS,
+    SKILL_MECHANICS,
     GLYPH_OVERRIDES,
     defaultNameFor,
     skillKey,
     inferRange,
-    computeDerivedStats
+    computeDerivedStats,
+    mechanicsForSkill
   };
 })(window);

--- a/index.html
+++ b/index.html
@@ -838,7 +838,48 @@ const AbilityLib={
 };
 
 const SKILL_BEHAVIORS = window.FABLE_DATA.SKILL_BEHAVIORS;
+const SKILL_MECHANICS = window.FABLE_DATA.SKILL_MECHANICS || {};
 const skillKey = window.FABLE_DATA.skillKey;
+
+function deriveRange(raw, fallback){
+  if(raw==null) return fallback;
+  if(typeof raw === 'number' && Number.isFinite(raw)) return raw;
+  const str = String(raw).toLowerCase();
+  if(str.includes('self') && !/(\d+)/.test(str) && !str.includes('adjacent')) return 0;
+  if(str.includes('adjacent')) return Math.max(1, fallback ?? 1);
+  if(str.includes('melee')) return 1;
+  if(str.includes('cone')) return fallback ?? 2;
+  const match = str.match(/(\d+)/);
+  if(match) return parseInt(match[1],10);
+  return fallback;
+}
+
+function deriveCooldown(raw, fallback){
+  if(typeof raw === 'number' && Number.isFinite(raw)) return raw;
+  const parsed = parseInt(raw, 10);
+  if(Number.isFinite(parsed)) return parsed;
+  return fallback;
+}
+
+function deriveDescription(name, effect, fallback){
+  if(effect && effect.trim){
+    const trimmed = effect.trim();
+    if(trimmed.length){
+      return `${name}: ${/[.!?]$/.test(trimmed) ? trimmed : trimmed + '.'}`;
+    }
+  }
+  return fallback;
+}
+
+function abilityMeta(name, fallbackRange, fallbackCooldown, fallbackDesc){
+  const mech = SKILL_MECHANICS?.[name];
+  return {
+    mech,
+    range: deriveRange(mech?.range, fallbackRange),
+    cooldown: deriveCooldown(mech?.cooldown, fallbackCooldown),
+    desc: deriveDescription(name, mech?.effect, fallbackDesc)
+  };
+}
 
 function ensureAbilityForSkill(name){
   const key = skillKey(name);
@@ -849,136 +890,184 @@ function ensureAbilityForSkill(name){
 }
 
 function makeAbilityFromBehavior(name, behavior){
-  switch(behavior){
-    case 'attackRanged':
-      return {
-        name,
-        desc: `${name}: Ranged strike.`,
-        cooldown:1, range:3, target:'enemy',
-        use(user,target,log){
-          const atk = effAtk(user);
-          const dmg = computeDamage(atk, effDef(target));
-          applyDamage(target,dmg,log,`${user.name} uses ${name} on ${target.name} for <span class=\"dmg\">-${dmg}</span>.`);
-        }
-      };
-    case 'attackRangedRoot':
-      return {
-        name,
-        desc: `${name}: Ranged strike that roots.`,
-        cooldown:2, range:3, target:'enemy',
-        use(user,target,log){
-          const atk = effAtk(user);
-          const dmg = computeDamage(atk, effDef(target));
-          applyDamage(target,dmg,log,`${user.name} uses ${name} on ${target.name} for <span class=\"dmg\">-${dmg}</span>.`);
-          if(!target.dead){ addStatus(target,'Root',log); log(`${target.name} is rooted by ${name}.`); }
-        }
-      };
-    case 'attackMeleeBleed':
-      return {
-        name,
-        desc: `${name}: Close strike that bleeds.`,
-        cooldown:2, range:1, target:'enemy',
-        use(user,target,log){
-          const atk = effAtk(user);
-          const dmg = computeDamage(atk, effDef(target));
-          applyDamage(target,dmg,log,`${user.name} uses ${name} on ${target.name} for <span class=\"dmg\">-${dmg}</span>.`);
-          if(!target.dead){ addStatus(target,'Bleed',log); log(`${target.name} bleeds from ${name}.`); }
-        }
-      };
-    case 'attackLifeSteal':
-      return {
-        name,
-        desc: `${name}: Strike and siphon life.`,
-        cooldown:2, range:2, target:'enemy',
-        use(user,target,log){
-          const atk = effAtk(user);
-          const dmg = computeDamage(atk, effDef(target));
-          applyDamage(target,dmg,log,`${user.name} uses ${name} on ${target.name} for <span class=\"dmg\">-${dmg}</span>.`);
-          if(dmg>0 && !user.dead){
-            const before = user.hp;
-            user.hp = clamp(user.hp + Math.ceil(dmg/2), 0, user.stats.maxHp);
-            const healed = user.hp - before;
-            if(healed>0){ log(`${user.name} siphons <span class=\"heal\">+${healed}</span> HP.`); }
+    switch(behavior){
+      case 'attackRanged': {
+        const meta = abilityMeta(name, 3, 1, `${name}: Ranged strike.`);
+        return {
+          name,
+          desc: meta.desc,
+          cooldown: meta.cooldown,
+          range: meta.range,
+          target:'enemy',
+          use(user,target,log){
+            const atk = effAtk(user);
+            const dmg = computeDamage(atk, effDef(target));
+            applyDamage(target,dmg,log,`${user.name} uses ${name} on ${target.name} for <span class=\"dmg\">-${dmg}</span>.`);
           }
-        }
-      };
-    case 'buffSelfGuard':
-      return {
-        name,
-        desc: `${name}: Brace for impact.`,
-        cooldown:2, range:0, target:'self',
-        use(user,_target,log){ addStatus(user,'Guard',log); log(`${user.name} uses ${name} and steadies their defense.`); }
-      };
-    case 'buffSelfInspire':
-      return {
-        name,
-        desc: `${name}: Empower self.`,
-        cooldown:2, range:0, target:'self',
-        use(user,_target,log){ addStatus(user,'Inspire',log); log(`${user.name} channels ${name}.`); }
-      };
-    case 'buffAllyGuard':
-      return {
-        name,
-        desc: `${name}: Protect an ally.`,
-        cooldown:2, range:3, target:'ally',
-        use(user,target,log){ addStatus(target,'Guard',log); log(`${user.name} uses ${name} to shield ${target.name}.`); }
-      };
-    case 'buffAllyInspire':
-      return {
-        name,
-        desc: `${name}: Bolster an ally.`,
-        cooldown:2, range:3, target:'ally',
-        use(user,target,log){ addStatus(target,'Inspire',log); log(`${user.name} inspires ${target.name} with ${name}.`); }
-      };
-    case 'heal':
-      return {
-        name,
-        desc: `${name}: Restore an ally.`,
-        cooldown:2, range:3, target:'ally',
-        use(user,target,log){
-          const before = target.hp;
-          target.hp = clamp(target.hp + 18, 0, target.stats.maxHp);
-          const healed = target.hp - before;
-          log(`${user.name} uses ${name} on ${target.name} for <span class=\"heal\">+${healed}</span> HP.`);
-        }
-      };
-    case 'root':
-      return {
-        name,
-        desc: `${name}: Immobilize an enemy.`,
-        cooldown:2, range:3, target:'enemy',
-        use(user,target,log){ addStatus(target,'Root',log); log(`${user.name} uses ${name} to root ${target.name}.`); }
-      };
-    case 'swap':
-      return {
-        name,
-        desc: `${name}: Swap positions with an ally.`,
-        cooldown:2, range:3, target:'ally',
-        use(user,target,log){
-          if(user===target) return;
-          if(!user.pos || !target.pos){ log(`${name} fizzles; both units must be placed.`); return; }
-          const ux = user.pos.x, uy = user.pos.y;
-          user.pos.x = target.pos.x;
-          user.pos.y = target.pos.y;
-          target.pos.x = ux;
-          target.pos.y = uy;
-          log(`${user.name} swaps places with ${target.name} using ${name}.`);
-        }
-      };
-    case 'attackMelee':
-    default:
-      return {
-        name,
-        desc: `${name}: Close-range strike.`,
-        cooldown:1, range:1, target:'enemy',
-        use(user,target,log){
-          const atk = effAtk(user);
-          const dmg = computeDamage(atk, effDef(target));
-          applyDamage(target,dmg,log,`${user.name} uses ${name} on ${target.name} for <span class=\"dmg\">-${dmg}</span>.`);
-        }
-      };
+        };
+      }
+      case 'attackRangedRoot': {
+        const metaRoot = abilityMeta(name, 3, 2, `${name}: Ranged strike that roots.`);
+        return {
+          name,
+          desc: metaRoot.desc,
+          cooldown: metaRoot.cooldown,
+          range: metaRoot.range,
+          target:'enemy',
+          use(user,target,log){
+            const atk = effAtk(user);
+            const dmg = computeDamage(atk, effDef(target));
+            applyDamage(target,dmg,log,`${user.name} uses ${name} on ${target.name} for <span class=\"dmg\">-${dmg}</span>.`);
+            if(!target.dead){ addStatus(target,'Root',log); log(`${target.name} is rooted by ${name}.`); }
+          }
+        };
+      }
+      case 'attackMeleeBleed': {
+        const metaBleed = abilityMeta(name, 1, 2, `${name}: Close strike that bleeds.`);
+        return {
+          name,
+          desc: metaBleed.desc,
+          cooldown: metaBleed.cooldown,
+          range: metaBleed.range,
+          target:'enemy',
+          use(user,target,log){
+            const atk = effAtk(user);
+            const dmg = computeDamage(atk, effDef(target));
+            applyDamage(target,dmg,log,`${user.name} uses ${name} on ${target.name} for <span class=\"dmg\">-${dmg}</span>.`);
+            if(!target.dead){ addStatus(target,'Bleed',log); log(`${target.name} bleeds from ${name}.`); }
+          }
+        };
+      }
+      case 'attackLifeSteal': {
+        const metaLeech = abilityMeta(name, 2, 2, `${name}: Strike and siphon life.`);
+        return {
+          name,
+          desc: metaLeech.desc,
+          cooldown: metaLeech.cooldown,
+          range: metaLeech.range,
+          target:'enemy',
+          use(user,target,log){
+            const atk = effAtk(user);
+            const dmg = computeDamage(atk, effDef(target));
+            applyDamage(target,dmg,log,`${user.name} uses ${name} on ${target.name} for <span class=\"dmg\">-${dmg}</span>.`);
+            if(dmg>0 && !user.dead){
+              const before = user.hp;
+              user.hp = clamp(user.hp + Math.ceil(dmg/2), 0, user.stats.maxHp);
+              const healed = user.hp - before;
+              if(healed>0){ log(`${user.name} siphons <span class=\"heal\">+${healed}</span> HP.`); }
+            }
+          }
+        };
+      }
+      case 'buffSelfGuard': {
+        const metaGuardSelf = abilityMeta(name, 0, 2, `${name}: Brace for impact.`);
+        return {
+          name,
+          desc: metaGuardSelf.desc,
+          cooldown: metaGuardSelf.cooldown,
+          range: metaGuardSelf.range,
+          target:'self',
+          use(user,_target,log){ addStatus(user,'Guard',log); log(`${user.name} uses ${name} and steadies their defense.`); }
+        };
+      }
+      case 'buffSelfInspire': {
+        const metaInspireSelf = abilityMeta(name, 0, 2, `${name}: Empower self.`);
+        return {
+          name,
+          desc: metaInspireSelf.desc,
+          cooldown: metaInspireSelf.cooldown,
+          range: metaInspireSelf.range,
+          target:'self',
+          use(user,_target,log){ addStatus(user,'Inspire',log); log(`${user.name} channels ${name}.`); }
+        };
+      }
+      case 'buffAllyGuard': {
+        const metaGuardAlly = abilityMeta(name, 3, 2, `${name}: Protect an ally.`);
+        return {
+          name,
+          desc: metaGuardAlly.desc,
+          cooldown: metaGuardAlly.cooldown,
+          range: metaGuardAlly.range,
+          target:'ally',
+          use(user,target,log){ addStatus(target,'Guard',log); log(`${user.name} uses ${name} to shield ${target.name}.`); }
+        };
+      }
+      case 'buffAllyInspire': {
+        const metaInspireAlly = abilityMeta(name, 3, 2, `${name}: Bolster an ally.`);
+        return {
+          name,
+          desc: metaInspireAlly.desc,
+          cooldown: metaInspireAlly.cooldown,
+          range: metaInspireAlly.range,
+          target:'ally',
+          use(user,target,log){ addStatus(target,'Inspire',log); log(`${user.name} inspires ${target.name} with ${name}.`); }
+        };
+      }
+      case 'heal': {
+        const metaHeal = abilityMeta(name, 3, 2, `${name}: Restore an ally.`);
+        return {
+          name,
+          desc: metaHeal.desc,
+          cooldown: metaHeal.cooldown,
+          range: metaHeal.range,
+          target:'ally',
+          use(user,target,log){
+            const before = target.hp;
+            target.hp = clamp(target.hp + 18, 0, target.stats.maxHp);
+            const healed = target.hp - before;
+            log(`${user.name} uses ${name} on ${target.name} for <span class=\"heal\">+${healed}</span> HP.`);
+          }
+        };
+      }
+      case 'root': {
+        const metaRootOnly = abilityMeta(name, 3, 2, `${name}: Immobilize an enemy.`);
+        return {
+          name,
+          desc: metaRootOnly.desc,
+          cooldown: metaRootOnly.cooldown,
+          range: metaRootOnly.range,
+          target:'enemy',
+          use(user,target,log){ addStatus(target,'Root',log); log(`${user.name} uses ${name} to root ${target.name}.`); }
+        };
+      }
+      case 'swap': {
+        const metaSwap = abilityMeta(name, 3, 2, `${name}: Swap positions with an ally.`);
+        return {
+          name,
+          desc: metaSwap.desc,
+          cooldown: metaSwap.cooldown,
+          range: metaSwap.range,
+          target:'ally',
+          use(user,target,log){
+            if(user===target) return;
+            if(!user.pos || !target.pos){ log(`${name} fizzles; both units must be placed.`); return; }
+            const ux = user.pos.x, uy = user.pos.y;
+            user.pos.x = target.pos.x;
+            user.pos.y = target.pos.y;
+            target.pos.x = ux;
+            target.pos.y = uy;
+            log(`${user.name} swaps places with ${target.name} using ${name}.`);
+          }
+        };
+      }
+      case 'attackMelee':
+      default: {
+        const metaDefault = abilityMeta(name, 1, 1, `${name}: Close-range strike.`);
+        return {
+          name,
+          desc: metaDefault.desc,
+          cooldown: metaDefault.cooldown,
+          range: metaDefault.range,
+          target:'enemy',
+          use(user,target,log){
+            const atk = effAtk(user);
+            const dmg = computeDamage(atk, effDef(target));
+            applyDamage(target,dmg,log,`${user.name} uses ${name} on ${target.name} for <span class=\"dmg\">-${dmg}</span>.`);
+          }
+        };
+      }
+    }
   }
-}
 
 /* ========= Templates ========= */
 const UnitTemplates = Object.fromEntries(CLASS_ENTRIES.map(entry=>{

--- a/index.html
+++ b/index.html
@@ -881,6 +881,18 @@ function abilityMeta(name, fallbackRange, fallbackCooldown, fallbackDesc){
   };
 }
 
+function sanitizeRange(range, fallbackRange, targetType){
+  const fallback = fallbackRange ?? 1;
+  if(targetType === 'self') return 0;
+  if(range == null) return fallback;
+  if(typeof range === 'number'){
+    return range > 0 ? range : fallback;
+  }
+  const parsed = parseInt(range,10);
+  if(Number.isFinite(parsed) && parsed > 0) return parsed;
+  return fallback;
+}
+
 function ensureAbilityForSkill(name){
   const key = skillKey(name);
   if(AbilityLib[key]) return key;
@@ -892,12 +904,14 @@ function ensureAbilityForSkill(name){
 function makeAbilityFromBehavior(name, behavior){
     switch(behavior){
       case 'attackRanged': {
-        const meta = abilityMeta(name, 3, 1, `${name}: Ranged strike.`);
+        const fallbackRange = 3;
+        const fallbackCooldown = 1;
+        const meta = abilityMeta(name, fallbackRange, fallbackCooldown, `${name}: Ranged strike.`);
         return {
           name,
           desc: meta.desc,
           cooldown: meta.cooldown,
-          range: meta.range,
+          range: sanitizeRange(meta.range, fallbackRange, 'enemy'),
           target:'enemy',
           use(user,target,log){
             const atk = effAtk(user);
@@ -907,12 +921,14 @@ function makeAbilityFromBehavior(name, behavior){
         };
       }
       case 'attackRangedRoot': {
-        const metaRoot = abilityMeta(name, 3, 2, `${name}: Ranged strike that roots.`);
+        const fallbackRange = 3;
+        const fallbackCooldown = 2;
+        const metaRoot = abilityMeta(name, fallbackRange, fallbackCooldown, `${name}: Ranged strike that roots.`);
         return {
           name,
           desc: metaRoot.desc,
           cooldown: metaRoot.cooldown,
-          range: metaRoot.range,
+          range: sanitizeRange(metaRoot.range, fallbackRange, 'enemy'),
           target:'enemy',
           use(user,target,log){
             const atk = effAtk(user);
@@ -923,12 +939,14 @@ function makeAbilityFromBehavior(name, behavior){
         };
       }
       case 'attackMeleeBleed': {
-        const metaBleed = abilityMeta(name, 1, 2, `${name}: Close strike that bleeds.`);
+        const fallbackRange = 1;
+        const fallbackCooldown = 2;
+        const metaBleed = abilityMeta(name, fallbackRange, fallbackCooldown, `${name}: Close strike that bleeds.`);
         return {
           name,
           desc: metaBleed.desc,
           cooldown: metaBleed.cooldown,
-          range: metaBleed.range,
+          range: sanitizeRange(metaBleed.range, fallbackRange, 'enemy'),
           target:'enemy',
           use(user,target,log){
             const atk = effAtk(user);
@@ -939,12 +957,14 @@ function makeAbilityFromBehavior(name, behavior){
         };
       }
       case 'attackLifeSteal': {
-        const metaLeech = abilityMeta(name, 2, 2, `${name}: Strike and siphon life.`);
+        const fallbackRange = 2;
+        const fallbackCooldown = 2;
+        const metaLeech = abilityMeta(name, fallbackRange, fallbackCooldown, `${name}: Strike and siphon life.`);
         return {
           name,
           desc: metaLeech.desc,
           cooldown: metaLeech.cooldown,
-          range: metaLeech.range,
+          range: sanitizeRange(metaLeech.range, fallbackRange, 'enemy'),
           target:'enemy',
           use(user,target,log){
             const atk = effAtk(user);
@@ -960,56 +980,66 @@ function makeAbilityFromBehavior(name, behavior){
         };
       }
       case 'buffSelfGuard': {
-        const metaGuardSelf = abilityMeta(name, 0, 2, `${name}: Brace for impact.`);
+        const fallbackRange = 0;
+        const fallbackCooldown = 2;
+        const metaGuardSelf = abilityMeta(name, fallbackRange, fallbackCooldown, `${name}: Brace for impact.`);
         return {
           name,
           desc: metaGuardSelf.desc,
           cooldown: metaGuardSelf.cooldown,
-          range: metaGuardSelf.range,
+          range: sanitizeRange(metaGuardSelf.range, fallbackRange, 'self'),
           target:'self',
           use(user,_target,log){ addStatus(user,'Guard',log); log(`${user.name} uses ${name} and steadies their defense.`); }
         };
       }
       case 'buffSelfInspire': {
-        const metaInspireSelf = abilityMeta(name, 0, 2, `${name}: Empower self.`);
+        const fallbackRange = 0;
+        const fallbackCooldown = 2;
+        const metaInspireSelf = abilityMeta(name, fallbackRange, fallbackCooldown, `${name}: Empower self.`);
         return {
           name,
           desc: metaInspireSelf.desc,
           cooldown: metaInspireSelf.cooldown,
-          range: metaInspireSelf.range,
+          range: sanitizeRange(metaInspireSelf.range, fallbackRange, 'self'),
           target:'self',
           use(user,_target,log){ addStatus(user,'Inspire',log); log(`${user.name} channels ${name}.`); }
         };
       }
       case 'buffAllyGuard': {
-        const metaGuardAlly = abilityMeta(name, 3, 2, `${name}: Protect an ally.`);
+        const fallbackRange = 3;
+        const fallbackCooldown = 2;
+        const metaGuardAlly = abilityMeta(name, fallbackRange, fallbackCooldown, `${name}: Protect an ally.`);
         return {
           name,
           desc: metaGuardAlly.desc,
           cooldown: metaGuardAlly.cooldown,
-          range: metaGuardAlly.range,
+          range: sanitizeRange(metaGuardAlly.range, fallbackRange, 'ally'),
           target:'ally',
           use(user,target,log){ addStatus(target,'Guard',log); log(`${user.name} uses ${name} to shield ${target.name}.`); }
         };
       }
       case 'buffAllyInspire': {
-        const metaInspireAlly = abilityMeta(name, 3, 2, `${name}: Bolster an ally.`);
+        const fallbackRange = 3;
+        const fallbackCooldown = 2;
+        const metaInspireAlly = abilityMeta(name, fallbackRange, fallbackCooldown, `${name}: Bolster an ally.`);
         return {
           name,
           desc: metaInspireAlly.desc,
           cooldown: metaInspireAlly.cooldown,
-          range: metaInspireAlly.range,
+          range: sanitizeRange(metaInspireAlly.range, fallbackRange, 'ally'),
           target:'ally',
           use(user,target,log){ addStatus(target,'Inspire',log); log(`${user.name} inspires ${target.name} with ${name}.`); }
         };
       }
       case 'heal': {
-        const metaHeal = abilityMeta(name, 3, 2, `${name}: Restore an ally.`);
+        const fallbackRange = 3;
+        const fallbackCooldown = 2;
+        const metaHeal = abilityMeta(name, fallbackRange, fallbackCooldown, `${name}: Restore an ally.`);
         return {
           name,
           desc: metaHeal.desc,
           cooldown: metaHeal.cooldown,
-          range: metaHeal.range,
+          range: sanitizeRange(metaHeal.range, fallbackRange, 'ally'),
           target:'ally',
           use(user,target,log){
             const before = target.hp;
@@ -1020,23 +1050,27 @@ function makeAbilityFromBehavior(name, behavior){
         };
       }
       case 'root': {
-        const metaRootOnly = abilityMeta(name, 3, 2, `${name}: Immobilize an enemy.`);
+        const fallbackRange = 3;
+        const fallbackCooldown = 2;
+        const metaRootOnly = abilityMeta(name, fallbackRange, fallbackCooldown, `${name}: Immobilize an enemy.`);
         return {
           name,
           desc: metaRootOnly.desc,
           cooldown: metaRootOnly.cooldown,
-          range: metaRootOnly.range,
+          range: sanitizeRange(metaRootOnly.range, fallbackRange, 'enemy'),
           target:'enemy',
           use(user,target,log){ addStatus(target,'Root',log); log(`${user.name} uses ${name} to root ${target.name}.`); }
         };
       }
       case 'swap': {
-        const metaSwap = abilityMeta(name, 3, 2, `${name}: Swap positions with an ally.`);
+        const fallbackRange = 3;
+        const fallbackCooldown = 2;
+        const metaSwap = abilityMeta(name, fallbackRange, fallbackCooldown, `${name}: Swap positions with an ally.`);
         return {
           name,
           desc: metaSwap.desc,
           cooldown: metaSwap.cooldown,
-          range: metaSwap.range,
+          range: sanitizeRange(metaSwap.range, fallbackRange, 'ally'),
           target:'ally',
           use(user,target,log){
             if(user===target) return;
@@ -1052,12 +1086,14 @@ function makeAbilityFromBehavior(name, behavior){
       }
       case 'attackMelee':
       default: {
-        const metaDefault = abilityMeta(name, 1, 1, `${name}: Close-range strike.`);
+        const fallbackRange = 1;
+        const fallbackCooldown = 1;
+        const metaDefault = abilityMeta(name, fallbackRange, fallbackCooldown, `${name}: Close-range strike.`);
         return {
           name,
           desc: metaDefault.desc,
           cooldown: metaDefault.cooldown,
-          range: metaDefault.range,
+          range: sanitizeRange(metaDefault.range, fallbackRange, 'enemy'),
           target:'enemy',
           use(user,target,log){
             const atk = effAtk(user);


### PR DESCRIPTION
## Summary
- add a comprehensive mechanics dataset for all starting skills, including resource costs, range, cooldown, effect text, and synergy tags
- expose a mechanics lookup helper alongside existing class data exports
- leverage the mechanics data when generating abilities so ranges, cooldowns, and descriptions match the ruleset

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d55375987083249b340736d17780a4