### PR TITLE
Add unit icon showcase page and navigation link

### DIFF
--- a/game-setup.html
+++ b/game-setup.html
@@ -426,6 +426,7 @@
     <nav>
       <a href="index.html">Combat Board</a>
       <a href="selector.html">Party Selector</a>
+      <a href="unit-icons.html">Unit Icons</a>
     </nav>
   </header>
   <main>

--- a/index.html
+++ b/index.html
@@ -714,6 +714,7 @@
     <nav>
       <a href="game-setup.html">Game Setup</a>
       <a href="selector.html">Party Selector</a>
+      <a href="unit-icons.html">Unit Icons</a>
       <button id="navStartBtn" class="nav-btn primary" type="button">Start Battle</button>
       <button id="navAutoBtn" class="nav-btn" type="button" title="Let the AI play for you">Auto Battle</button>
     </nav>

--- a/selector.html
+++ b/selector.html
@@ -346,6 +346,7 @@
     <nav>
       <a href="index.html">Combat Board</a>
       <a href="game-setup.html">Game Setup</a>
+      <a href="unit-icons.html">Unit Icons</a>
     </nav>
   </header>
   <main>

--- a/unit-icons.html
+++ b/unit-icons.html
@@ -1,0 +1,446 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Fable Tactics – Unit Icons</title>
+  <style>
+    @import url('https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600;700&family=Unbounded:wght@600&display=swap');
+    :root {
+      --parchment:#f6edd8;
+      --parchment-dark:#e4d3ad;
+      --ink:#4a3822;
+      --ink-soft:#7c6646;
+      --frame:#3c2714;
+      --frame-highlight:#9c6b2d;
+      --accent-blue:#5676c7;
+      --accent-gold:#d7a94d;
+      --accent-teal:#3c8575;
+      --accent-ruby:#b75b52;
+      --accent-amber:#d38d3a;
+      --accent-forest:#5d8c48;
+    }
+    * { box-sizing:border-box; font-family:'Outfit', system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif; }
+    body {
+      margin:0;
+      min-height:100vh;
+      background:var(--parchment);
+      color:var(--ink);
+      position:relative;
+      overflow-x:hidden;
+    }
+    body::before {
+      content:"";
+      position:fixed;
+      inset:-120px;
+      background:
+        radial-gradient(circle at 20% 20%, rgba(255,255,255,.25) 0%, transparent 48%),
+        radial-gradient(circle at 80% 18%, rgba(232,209,168,.35) 0%, transparent 52%),
+        linear-gradient(140deg, rgba(255,255,255,.25) 0%, rgba(232,209,168,0) 50%),
+        repeating-linear-gradient(45deg, rgba(149,118,68,.08) 0 12px, transparent 12px 24px);
+      mix-blend-mode:multiply;
+      opacity:.8;
+      pointer-events:none;
+      z-index:-2;
+    }
+    header {
+      display:flex;
+      align-items:center;
+      gap:20px;
+      padding:22px 26px;
+      border-bottom:3px solid rgba(60,39,20,.18);
+      background:linear-gradient(180deg, rgba(243,231,205,.92), rgba(233,214,177,.86));
+      position:sticky;
+      top:0;
+      z-index:4;
+      box-shadow:0 10px 24px rgba(76,54,26,.22);
+    }
+    header h1 {
+      margin:0;
+      font-family:'Unbounded','Outfit',system-ui;
+      font-size:22px;
+      letter-spacing:.32em;
+      text-transform:uppercase;
+      color:var(--ink);
+    }
+    header nav {
+      display:flex;
+      gap:12px;
+      margin-left:auto;
+    }
+    header nav a {
+      text-decoration:none;
+      color:var(--ink);
+      font-size:12px;
+      letter-spacing:.18em;
+      text-transform:uppercase;
+      padding:9px 14px;
+      border-radius:999px;
+      border:1px solid rgba(76,54,26,.28);
+      background:rgba(255,255,255,.68);
+      box-shadow:0 6px 16px rgba(76,54,26,.18);
+      transition:transform .18s ease, box-shadow .18s ease;
+    }
+    header nav a:hover {
+      transform:translateY(-2px);
+      box-shadow:0 12px 24px rgba(76,54,26,.22);
+    }
+    main {
+      max-width:1100px;
+      margin:0 auto;
+      padding:40px 26px 80px;
+    }
+    .intro {
+      max-width:720px;
+      margin-bottom:28px;
+      font-size:16px;
+      line-height:1.6;
+      color:var(--ink-soft);
+    }
+    .icon-grid {
+      display:grid;
+      gap:26px;
+      grid-template-columns:repeat(auto-fit, minmax(210px, 1fr));
+    }
+    .unit-card {
+      position:relative;
+      padding:22px 22px 26px;
+      border-radius:22px;
+      background:linear-gradient(180deg, rgba(255,255,255,.95), rgba(245,229,196,.92));
+      box-shadow:0 18px 34px rgba(76,54,26,.2);
+      border:1px solid rgba(76,54,26,.18);
+    }
+    .unit-card::before {
+      content:"";
+      position:absolute;
+      inset:10px;
+      border-radius:16px;
+      border:2px dashed rgba(76,54,26,.18);
+      pointer-events:none;
+    }
+    .unit-card header {
+      position:relative;
+      background:none;
+      padding:0;
+      border:none;
+      box-shadow:none;
+      display:flex;
+      flex-direction:column;
+      align-items:flex-start;
+      gap:6px;
+    }
+    .unit-card header::after,
+    .unit-card header::before { display:none; }
+    .label {
+      font-size:11px;
+      letter-spacing:.28em;
+      text-transform:uppercase;
+      color:rgba(74,56,34,.6);
+    }
+    .unit-name {
+      font-family:'Unbounded','Outfit',system-ui;
+      font-size:20px;
+      letter-spacing:.05em;
+      margin:0;
+      color:var(--ink);
+    }
+    .icon-wrap {
+      margin:18px auto 16px;
+      width:148px;
+      height:148px;
+      border-radius:24px;
+      position:relative;
+      padding:18px;
+      background:linear-gradient(180deg, rgba(255,255,255,.95), rgba(250,232,200,.9));
+      box-shadow:inset 0 0 0 2px rgba(255,255,255,.7), inset 0 -16px 24px rgba(156,109,45,.22);
+      display:flex;
+      align-items:center;
+      justify-content:center;
+    }
+    .icon-wrap::after {
+      content:"";
+      position:absolute;
+      inset:10px;
+      border-radius:18px;
+      background:radial-gradient(circle at 30% 25%, rgba(255,255,255,.45), transparent 65%);
+      opacity:.7;
+      pointer-events:none;
+    }
+    .unit-icon {
+      width:100%;
+      height:100%;
+    }
+    .unit-card footer {
+      font-size:12px;
+      color:var(--ink-soft);
+      display:flex;
+      flex-direction:column;
+      gap:6px;
+      line-height:1.6;
+    }
+    .accent-tag {
+      display:inline-flex;
+      align-items:center;
+      gap:8px;
+      font-size:11px;
+      letter-spacing:.2em;
+      text-transform:uppercase;
+      background:rgba(74,56,34,.08);
+      border-radius:999px;
+      padding:6px 12px;
+      color:var(--ink);
+      align-self:flex-start;
+    }
+    .accent-dot {
+      width:14px;
+      height:14px;
+      border-radius:50%;
+      box-shadow:0 0 0 2px rgba(255,255,255,.4), 0 0 0 4px rgba(74,56,34,.12);
+    }
+    .accent-knight { background:linear-gradient(135deg, var(--accent-blue), #2e457f); }
+    .accent-mage { background:linear-gradient(135deg, var(--accent-teal), #2a5860); }
+    .accent-explorer { background:linear-gradient(135deg, var(--accent-amber), #915c25); }
+    .accent-villager { background:linear-gradient(135deg, var(--accent-gold), #a8702d); }
+    .accent-elder { background:linear-gradient(135deg, var(--accent-ruby), #7b3a36); }
+    .accent-fae { background:linear-gradient(135deg, var(--accent-forest), #38582c); }
+    .lore-note {
+      font-size:12px;
+      font-style:italic;
+      color:rgba(74,56,34,.65);
+    }
+    svg .stroke { stroke:#2d1f0f; stroke-linecap:round; stroke-linejoin:round; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Fable Tactics</h1>
+    <nav>
+      <a href="index.html">Battle UI</a>
+      <a href="game-setup.html">Game Setup</a>
+      <a href="selector.html">Party Selector</a>
+      <a href="unit-icons.html">Unit Icons</a>
+    </nav>
+  </header>
+  <main>
+    <p class="intro">
+      The folk of the realms gather beneath banners and sigils that echo their stories. Each badge captures a silhouette, a cherished tool, and a touch of seasonal color pulled from the illustration compendium. These static icons are designed for party sheets, tooltips, and roster summaries.
+    </p>
+    <section class="icon-grid">
+      <article class="unit-card">
+        <header>
+          <span class="label">Shieldward Line</span>
+          <h2 class="unit-name">Knight</h2>
+        </header>
+        <span class="accent-tag"><span class="accent-dot accent-knight"></span>Frontline</span>
+        <div class="icon-wrap">
+          <svg class="unit-icon" viewBox="0 0 120 120" fill="none">
+            <defs>
+              <linearGradient id="knight-bg" x1="20" y1="10" x2="100" y2="110" gradientUnits="userSpaceOnUse">
+                <stop offset="0" stop-color="#6f86d6" />
+                <stop offset="1" stop-color="#3a4c92" />
+              </linearGradient>
+              <linearGradient id="knight-steel" x1="40" y1="20" x2="90" y2="100" gradientUnits="userSpaceOnUse">
+                <stop offset="0" stop-color="#dbe6ff" />
+                <stop offset="1" stop-color="#9aa4c7" />
+              </linearGradient>
+            </defs>
+            <g>
+              <circle cx="60" cy="60" r="52" fill="url(#knight-bg)" opacity="0.9" />
+              <path d="M60 28c-12 0-22 8-22 18v14c0 15 10 26 22 26s22-11 22-26V46c0-10-10-18-22-18Z" fill="url(#knight-steel)" class="stroke" stroke-width="3" />
+              <path d="M44 46h32v8c0 8-7 14-16 14s-16-6-16-14v-8Z" fill="#405089" class="stroke" stroke-width="3" />
+              <path d="M48 34c4-6 24-6 28 0" stroke="#31406f" stroke-width="4" stroke-linecap="round" opacity="0.6" />
+              <path d="M58 34h4v18h-4z" fill="#2d1f0f" opacity="0.28" />
+              <path d="M24 60c-3 0-6 2-6 5v26c0 5 5 9 10 7l20-7" fill="#d8b98a" class="stroke" stroke-width="3" />
+              <path d="M34 70 22 74v12l18-6" fill="#b3894e" class="stroke" stroke-width="3" />
+              <path d="M96 52c0-6-8-10-14-6l-6 4 4 6c2 4 8 5 12 2 2-2 4-4 4-6Z" fill="#f3d5a6" class="stroke" stroke-width="3" />
+              <path d="M86 50 78 92c-1 6 4 11 10 11h6c4 0 6-4 6-8l-4-36" fill="#cfa55a" class="stroke" stroke-width="3" />
+              <path d="m102 40-6 12" stroke="#2d1f0f" stroke-width="4" stroke-linecap="round" />
+            </g>
+          </svg>
+        </div>
+        <footer>
+          <div>Polished steel with painted trim conveys the disciplined regiments of Castellum.</div>
+          <div class="lore-note">Pinned to fortified gates to signal a watchful garrison.</div>
+        </footer>
+      </article>
+      <article class="unit-card">
+        <header>
+          <span class="label">Aether Circle</span>
+          <h2 class="unit-name">Magician</h2>
+        </header>
+        <span class="accent-tag"><span class="accent-dot accent-mage"></span>Spellcraft</span>
+        <div class="icon-wrap">
+          <svg class="unit-icon" viewBox="0 0 120 120" fill="none">
+            <defs>
+              <radialGradient id="mage-bg" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(60 60) rotate(90) scale(52)">
+                <stop offset="0" stop-color="#64c7c0" />
+                <stop offset="1" stop-color="#245d74" />
+              </radialGradient>
+              <linearGradient id="mage-hat" x1="40" y1="22" x2="88" y2="66" gradientUnits="userSpaceOnUse">
+                <stop offset="0" stop-color="#0f3a46" />
+                <stop offset="1" stop-color="#1b6b7f" />
+              </linearGradient>
+            </defs>
+            <circle cx="60" cy="60" r="52" fill="url(#mage-bg)" opacity="0.9" />
+            <path d="M32 74c8-6 48-6 56 0" stroke="#0e2433" stroke-width="6" stroke-linecap="round" opacity=".45" />
+            <path d="M40 62c8 8 32 8 40 0" stroke="#0e2433" stroke-width="6" stroke-linecap="round" opacity=".25" />
+            <path d="m36 52 16-34c3-6 13-6 16 0l16 34" fill="url(#mage-hat)" class="stroke" stroke-width="3" />
+            <path d="M28 76h64c2 0 4 2 4 4s-2 4-4 4H28c-2 0-4-2-4-4s2-4 4-4Z" fill="#e6c87a" class="stroke" stroke-width="3" />
+            <path d="M60 22v68" stroke="#e8e2c0" stroke-width="4" stroke-linecap="round" opacity=".5" />
+            <path d="M86 26c6-6 16 0 12 8l-10 18" fill="#f0d5a4" class="stroke" stroke-width="3" />
+            <circle cx="90" cy="22" r="6" fill="#f7b23c" stroke="#2d1f0f" stroke-width="3" />
+            <circle cx="90" cy="22" r="3" fill="#fff9dd" />
+            <path d="M46 72c2 6 6 12 14 12s12-6 14-12" stroke="#1f4154" stroke-width="4" stroke-linecap="round" />
+          </svg>
+        </div>
+        <footer>
+          <div>Star-scribed hat silhouettes and celestial glows draw from the atelier's spell folios.</div>
+          <div class="lore-note">Used by guild wayfinders when recruiting apprentices.</div>
+        </footer>
+      </article>
+      <article class="unit-card">
+        <header>
+          <span class="label">Trailbound</span>
+          <h2 class="unit-name">Explorer</h2>
+        </header>
+        <span class="accent-tag"><span class="accent-dot accent-explorer"></span>Pathfinder</span>
+        <div class="icon-wrap">
+          <svg class="unit-icon" viewBox="0 0 120 120" fill="none">
+            <defs>
+              <linearGradient id="explorer-bg" x1="24" y1="16" x2="100" y2="110" gradientUnits="userSpaceOnUse">
+                <stop offset="0" stop-color="#f2c97d" />
+                <stop offset="1" stop-color="#9b6431" />
+              </linearGradient>
+              <linearGradient id="explorer-pack" x1="40" y1="46" x2="84" y2="98" gradientUnits="userSpaceOnUse">
+                <stop offset="0" stop-color="#8a5c32" />
+                <stop offset="1" stop-color="#4f3019" />
+              </linearGradient>
+            </defs>
+            <circle cx="60" cy="60" r="52" fill="url(#explorer-bg)" opacity="0.9" />
+            <path d="M54 24c-6 0-10 4-10 8v8c0 6 4 10 10 10h12c6 0 10-4 10-10v-8c0-4-4-8-10-8H54Z" fill="#f0d5a4" class="stroke" stroke-width="3" />
+            <path d="M38 48c-5 0-10 4-10 10v6c0 4 4 8 8 8h8" fill="#e2b873" class="stroke" stroke-width="3" />
+            <path d="M82 48c5 0 10 4 10 10v6c0 4-4 8-8 8h-8" fill="#e2b873" class="stroke" stroke-width="3" />
+            <path d="M42 40c4-10 32-10 36 0" stroke="#915c25" stroke-width="6" stroke-linecap="round" opacity=".4" />
+            <path d="M58 62h4v34h-4z" fill="#d7b078" />
+            <path d="M40 66h40v28c0 6-6 10-12 10H52c-6 0-12-4-12-10V66Z" fill="url(#explorer-pack)" class="stroke" stroke-width="3" />
+            <path d="m36 72-14 10" stroke="#2d1f0f" stroke-width="4" stroke-linecap="round" />
+            <path d="m84 72 14 10" stroke="#2d1f0f" stroke-width="4" stroke-linecap="round" />
+            <path d="M60 82c-10 0-18 8-18 18h36c0-10-8-18-18-18Z" fill="#dfb16c" class="stroke" stroke-width="3" />
+            <path d="M48 94h24" stroke="#f8e3b7" stroke-width="4" stroke-linecap="round" />
+            <path d="M56 32c-4 0-4 6 0 6h8c4 0 4-6 0-6h-8Z" fill="#915c25" />
+          </svg>
+        </div>
+        <footer>
+          <div>Leather packs, brimmed hats, and trail-mark lines nod to the expedition sprites.</div>
+          <div class="lore-note">Burnished onto compass lids gifted to caravan leaders.</div>
+        </footer>
+      </article>
+      <article class="unit-card">
+        <header>
+          <span class="label">Village Hearth</span>
+          <h2 class="unit-name">Caretaker</h2>
+        </header>
+        <span class="accent-tag"><span class="accent-dot accent-villager"></span>Support</span>
+        <div class="icon-wrap">
+          <svg class="unit-icon" viewBox="0 0 120 120" fill="none">
+            <defs>
+              <radialGradient id="caretaker-bg" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(60 60) rotate(90) scale(52)">
+                <stop offset="0" stop-color="#f7d89c" />
+                <stop offset="1" stop-color="#b67b3d" />
+              </radialGradient>
+            </defs>
+            <circle cx="60" cy="60" r="52" fill="url(#caretaker-bg)" opacity="0.9" />
+            <path d="M42 34c-6 0-10 6-10 12v8c0 10 8 18 18 18h20c10 0 18-8 18-18v-8c0-6-4-12-10-12H42Z" fill="#f0d9b5" class="stroke" stroke-width="3" />
+            <path d="M38 40c6-10 38-10 44 0" stroke="#b8793f" stroke-width="6" stroke-linecap="round" opacity=".45" />
+            <path d="M46 54h28" stroke="#2d1f0f" stroke-width="5" stroke-linecap="round" opacity=".25" />
+            <path d="M30 70c-6 0-10 4-10 10s4 10 10 10h12c6 0 10-4 10-10" fill="#e4b678" class="stroke" stroke-width="3" />
+            <path d="M90 70c6 0 10 4 10 10s-4 10-10 10H78c-6 0-10-4-10-10" fill="#e4b678" class="stroke" stroke-width="3" />
+            <path d="M48 84c0 8 6 14 12 14s12-6 12-14" stroke="#b8793f" stroke-width="5" stroke-linecap="round" />
+            <path d="M48 82c-8 0-14 6-14 14" stroke="#7f5126" stroke-width="4" stroke-linecap="round" />
+            <path d="M86 82c8 0 14 6 14 14" stroke="#7f5126" stroke-width="4" stroke-linecap="round" />
+            <path d="M56 32c0-8 8-8 8 0v8h-8v-8Z" fill="#e2b873" class="stroke" stroke-width="2" />
+            <path d="M50 72c0 6 4 10 10 10h0c6 0 10-4 10-10" stroke="#eacfa2" stroke-width="5" stroke-linecap="round" />
+          </svg>
+        </div>
+        <footer>
+          <div>Soft parchment tones and shawl curves match the gentle rhythm of village NPC portraits.</div>
+          <div class="lore-note">Given to hearthwardens who oversee festival preparations.</div>
+        </footer>
+      </article>
+      <article class="unit-card">
+        <header>
+          <span class="label">Twilight Council</span>
+          <h2 class="unit-name">Elder</h2>
+        </header>
+        <span class="accent-tag"><span class="accent-dot accent-elder"></span>Wisdom</span>
+        <div class="icon-wrap">
+          <svg class="unit-icon" viewBox="0 0 120 120" fill="none">
+            <defs>
+              <linearGradient id="elder-bg" x1="16" y1="20" x2="104" y2="104" gradientUnits="userSpaceOnUse">
+                <stop offset="0" stop-color="#f0b6a2" />
+                <stop offset="1" stop-color="#7b3640" />
+              </linearGradient>
+              <linearGradient id="elder-robes" x1="36" y1="54" x2="92" y2="110" gradientUnits="userSpaceOnUse">
+                <stop offset="0" stop-color="#b06054" />
+                <stop offset="1" stop-color="#6a2c32" />
+              </linearGradient>
+            </defs>
+            <circle cx="60" cy="60" r="52" fill="url(#elder-bg)" opacity="0.9" />
+            <path d="M54 28c-10 0-18 8-18 18v6c0 10 8 18 18 18h12c10 0 18-8 18-18v-6c0-10-8-18-18-18H54Z" fill="#f8dfc4" class="stroke" stroke-width="3" />
+            <path d="M40 44c6-12 34-12 40 0" stroke="#8a4043" stroke-width="6" stroke-linecap="round" opacity=".4" />
+            <path d="M46 50c2 8 8 12 14 12s12-4 14-12" stroke="#2d1f0f" stroke-width="4" stroke-linecap="round" opacity=".25" />
+            <path d="M42 64h36v32c0 10-8 18-18 18s-18-8-18-18V64Z" fill="url(#elder-robes)" class="stroke" stroke-width="3" />
+            <path d="M36 70c-6 0-10 4-10 10s4 10 10 10" stroke="#6a2c32" stroke-width="4" stroke-linecap="round" />
+            <path d="M84 70c6 0 10 4 10 10s-4 10-10 10" stroke="#6a2c32" stroke-width="4" stroke-linecap="round" />
+            <path d="M58 86h4" stroke="#f3d8c6" stroke-width="6" stroke-linecap="round" />
+            <path d="M60 30c-6 0-12 6-12 12" stroke="#f3d8c6" stroke-width="6" stroke-linecap="round" />
+            <path d="M60 30c6 0 12 6 12 12" stroke="#f3d8c6" stroke-width="6" stroke-linecap="round" />
+            <path d="M50 96h20" stroke="#f3d8c6" stroke-width="6" stroke-linecap="round" opacity=".5" />
+          </svg>
+        </div>
+        <footer>
+          <div>Wine-red robes and scroll silhouettes echo the parchment codex for companion lore.</div>
+          <div class="lore-note">Displayed in town halls to mark a seat on the council.</div>
+        </footer>
+      </article>
+      <article class="unit-card">
+        <header>
+          <span class="label">Fae Kinship</span>
+          <h2 class="unit-name">Sprite Ally</h2>
+        </header>
+        <span class="accent-tag"><span class="accent-dot accent-fae"></span>Support</span>
+        <div class="icon-wrap">
+          <svg class="unit-icon" viewBox="0 0 120 120" fill="none">
+            <defs>
+              <radialGradient id="fae-bg" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(60 60) rotate(90) scale(52)">
+                <stop offset="0" stop-color="#9bd67a" />
+                <stop offset="1" stop-color="#4a7c36" />
+              </radialGradient>
+              <linearGradient id="fae-tunic" x1="40" y1="54" x2="88" y2="106" gradientUnits="userSpaceOnUse">
+                <stop offset="0" stop-color="#e4d889" />
+                <stop offset="1" stop-color="#b69c46" />
+              </linearGradient>
+            </defs>
+            <circle cx="60" cy="60" r="52" fill="url(#fae-bg)" opacity="0.9" />
+            <path d="M46 30c-8 0-12 8-12 14v6c0 10 8 18 18 18h16c10 0 18-8 18-18v-6c0-6-4-14-12-14H46Z" fill="#f8e8b7" class="stroke" stroke-width="3" />
+            <path d="M42 36c6-12 30-12 36 0" stroke="#6a8f3c" stroke-width="6" stroke-linecap="round" opacity=".45" />
+            <path d="M38 52c-8 0-14 8-14 16s6 16 14 16" stroke="#4a7c36" stroke-width="4" stroke-linecap="round" />
+            <path d="M82 52c8 0 14 8 14 16s-6 16-14 16" stroke="#4a7c36" stroke-width="4" stroke-linecap="round" />
+            <path d="M44 64h32v28c0 8-6 14-16 14s-16-6-16-14V64Z" fill="url(#fae-tunic)" class="stroke" stroke-width="3" />
+            <path d="M52 82c0 6 4 10 8 10s8-4 8-10" stroke="#f8ecc7" stroke-width="5" stroke-linecap="round" />
+            <path d="M60 30c-8 0-8 12 0 12s8-12 0-12Z" fill="#d9c26d" class="stroke" stroke-width="2" />
+            <path d="M30 54c-6-6-14-2-12 6 2 6 10 8 16 4" fill="#d4f1a8" class="stroke" stroke-width="3" />
+            <path d="M28 48c-6-4-8-12-2-16 6-4 14 0 16 6" stroke="#f8ecc7" stroke-width="4" stroke-linecap="round" opacity=".6" />
+            <path d="M90 54c6-6 14-2 12 6-2 6-10 8-16 4" fill="#d4f1a8" class="stroke" stroke-width="3" />
+            <path d="M92 48c6-4 8-12 2-16-6-4-14 0-16 6" stroke="#f8ecc7" stroke-width="4" stroke-linecap="round" opacity=".6" />
+          </svg>
+        </div>
+        <footer>
+          <div>Leafy ears, bright tunics, and fluttering wings reference the folk companion card artwork.</div>
+          <div class="lore-note">Embossed on vellum invitations to fae courts.</div>
+        </footer>
+      </article>
+    </section>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a parchment-inspired Unit Icons page that showcases six static SVG badges for key unit archetypes
- craft icon cards with custom gradients, lore notes, and navigation consistent with the other tools
- update existing navigation menus to include the new Unit Icons view for quick access

## Testing
- not run (static content only)


------
https://chatgpt.com/codex/tasks/task_e_68d57c772a308324b21896629c462b35