### PR TITLE
Convert quick setup panel into dropdown overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -140,50 +140,73 @@
     pointer-events:none;
   }
   .panel:hover::after { opacity:1; }
-  .panel.collapsible {
-    padding-top:14px;
-    padding-bottom:14px;
+  .setup-dropdown {
+    position:fixed;
+    top:82px;
+    right:24px;
+    width:min(420px, calc(100% - 32px));
+    z-index:9;
+    animation:dropdownFade .18s ease-out;
   }
-  .panel.collapsible .collapsible-header {
+  .setup-dropdown[hidden] {
+    display:none;
+  }
+  .setup-dropdown .panel {
+    padding:18px 18px 22px;
+    max-height:min(78vh, 560px);
+    overflow:auto;
+  }
+  .setup-backdrop {
+    position:fixed;
+    inset:0;
+    background:rgba(3,6,15,.58);
+    backdrop-filter:blur(4px);
+    z-index:8;
+  }
+  .setup-backdrop[hidden] {
+    display:none;
+  }
+  .dropdown-header {
     display:flex;
     align-items:center;
     gap:12px;
     margin-bottom:12px;
   }
-  .panel.collapsible.collapsed .collapsible-header {
-    margin-bottom:0;
-  }
-  .panel.collapsible .collapsible-header h2 {
+  .dropdown-header h2 {
     margin:0;
   }
-  .collapse-toggle {
+  .icon-btn {
     margin-left:auto;
-    padding:6px 12px;
-    font-size:11px;
-    letter-spacing:.18em;
-    text-transform:uppercase;
-    color:var(--muted);
     background:rgba(20,26,40,.85);
     border:1px solid rgba(64,82,124,.75);
-    border-radius:999px;
-    display:inline-flex;
-    align-items:center;
-    gap:8px;
+    color:var(--muted);
+    border-radius:8px;
+    padding:4px 8px;
+    font-size:18px;
+    line-height:1;
   }
-  .collapse-toggle:hover {
-    border-color:rgba(114,153,255,.85);
+  .icon-btn:hover {
     color:#fff;
+    border-color:rgba(114,153,255,.85);
   }
-  .collapse-toggle .toggle-icon {
-    display:inline-block;
-    transition:transform .25s ease;
-    font-size:12px;
+  .setup-dropdown .divider:first-of-type {
+    margin-top:4px;
   }
-  #setupPanel.collapsed .collapse-toggle .toggle-icon {
-    transform:rotate(-90deg);
+  header nav button.nav-btn.active {
+    color:#fff;
+    border-color:rgba(127,230,162,.8);
+    box-shadow:0 0 0 1px rgba(127,230,162,.22);
   }
-  .collapsible-content[hidden] {
-    display:none;
+  @keyframes dropdownFade {
+    from { transform:translateY(-8px); opacity:0; }
+    to { transform:translateY(0); opacity:1; }
+  }
+  @media (max-width: 720px) {
+    .setup-dropdown {
+      left:12px;
+      right:12px;
+      width:auto;
+    }
   }
   .board { grid-area:board; }
   .side { grid-area:side; display:grid; gap:18px; }
@@ -715,11 +738,77 @@
       <a href="game-setup.html">Game Setup</a>
       <a href="selector.html">Party Selector</a>
       <a href="unit-icons.html">Unit Icons</a>
+      <button id="quickSetupBtn" class="nav-btn" type="button" aria-haspopup="true" aria-expanded="false" aria-controls="setupDropdown">Quick Setup</button>
       <button id="navStartBtn" class="nav-btn primary" type="button">Start Battle</button>
       <button id="navAutoBtn" class="nav-btn" type="button" title="Let the AI play for you">Auto Battle</button>
     </nav>
     <button id="resetBtn" class="warn" type="button">Reset Board</button>
   </header>
+  <div id="setupBackdrop" class="setup-backdrop" hidden></div>
+  <div id="setupDropdown" class="setup-dropdown" role="dialog" aria-modal="true" aria-labelledby="setupHeading" hidden>
+    <section class="panel" id="setupPanel">
+      <div class="dropdown-header">
+        <h2 id="setupHeading">Quick Setup</h2>
+        <button id="setupCloseBtn" class="icon-btn" type="button" aria-label="Close quick setup"><span aria-hidden="true">×</span></button>
+      </div>
+      <div class="small">Choose build/team. Toggle obstacle or terrain painting. Water is impassable. Obstacles block LOS.</div>
+      <div class="divider"></div>
+
+      <div class="btn-row" style="margin-bottom:8px">
+        <label><input type="radio" name="team" value="ally" checked> Allies</label>
+        <label><input type="radio" name="team" value="enemy"> Enemies</label>
+      </div>
+
+      <div class="btn-row" id="buildRow"></div>
+
+      <div class="divider"></div>
+
+      <!-- Grid size + zoom -->
+      <div class="btn-row" style="flex-wrap:wrap; align-items:center">
+        <div class="small">Grid:</div>
+        <label class="small">W <input id="gridW" type="number" min="4" max="16" value="8"></label>
+        <label class="small">H <input id="gridH" type="number" min="3" max="12" value="6"></label>
+        <button id="applyGridBtn" class="ghost">Apply</button>
+
+        <div class="small" style="margin-left:16px">Zoom:</div>
+        <input id="zoomRange" type="range" min="16" max="96" value="72" step="2">
+        <span id="zoomVal" class="small mono">72px</span>
+      </div>
+
+      <div class="btn-row">
+        <button id="obstacleBtn" class="ghost">Obstacle Mode: OFF</button>
+        <button id="clearObsBtn" class="ghost">Clear Obstacles</button>
+      </div>
+
+      <div class="btn-row" style="align-items:center">
+        <button id="terrainBtn" class="ghost">Terrain Mode: OFF</button>
+        <select id="terrainType">
+          <option value="plain">Plain</option>
+          <option value="forest">Forest (+2 DEF, cost 2)</option>
+          <option value="hill">Hill (+2 ATK, cost 2)</option>
+          <option value="road">Road (cost 1)</option>
+          <option value="swamp">Swamp (-2 ATK, cost 3)</option>
+          <option value="water">Water (impassable)</option>
+        </select>
+      </div>
+
+      <div class="legend">
+        <div class="lg"><span class="dot t-forest"></span>Forest</div>
+        <div class="lg"><span class="dot t-hill"></span>Hill</div>
+        <div class="lg"><span class="dot t-road"></span>Road</div>
+        <div class="lg"><span class="dot t-swamp"></span>Swamp</div>
+        <div class="lg"><span class="dot t-water"></span>Water</div>
+      </div>
+
+      <div class="divider"></div>
+      <div class="btn-row">
+        <button id="presetBtn" class="ghost">Preset: Bridge Clash</button>
+        <button id="fromSelectorBtn" class="ghost">Preset: From Selector</button>
+        <button id="clearBtn" class="ghost">Clear Units</button>
+        <button id="startBtn" class="primary">Start Battle</button>
+      </div>
+    </section>
+  </div>
   <main>
     <section class="panel board">
       <h2 id="phaseTitle">Setup: Place Units & Terrain</h2>
@@ -728,74 +817,6 @@
     </section>
 
     <section class="side">
-      <section class="panel collapsible collapsed" id="setupPanel">
-        <div class="collapsible-header">
-          <h2>Quick Setup</h2>
-          <button id="setupToggle" class="collapse-toggle" type="button" aria-expanded="false" aria-controls="setupContent">
-            <span class="toggle-label">Expand</span>
-            <span class="toggle-icon" aria-hidden="true">▾</span>
-          </button>
-        </div>
-        <div id="setupContent" class="collapsible-content" hidden>
-          <div class="small">Choose build/team. Toggle obstacle or terrain painting. Water is impassable. Obstacles block LOS.</div>
-          <div class="divider"></div>
-
-          <div class="btn-row" style="margin-bottom:8px">
-            <label><input type="radio" name="team" value="ally" checked> Allies</label>
-            <label><input type="radio" name="team" value="enemy"> Enemies</label>
-          </div>
-
-          <div class="btn-row" id="buildRow"></div>
-
-          <div class="divider"></div>
-
-          <!-- Grid size + zoom -->
-          <div class="btn-row" style="flex-wrap:wrap; align-items:center">
-            <div class="small">Grid:</div>
-            <label class="small">W <input id="gridW" type="number" min="4" max="16" value="8"></label>
-            <label class="small">H <input id="gridH" type="number" min="3" max="12" value="6"></label>
-            <button id="applyGridBtn" class="ghost">Apply</button>
-
-            <div class="small" style="margin-left:16px">Zoom:</div>
-            <input id="zoomRange" type="range" min="16" max="96" value="72" step="2">
-            <span id="zoomVal" class="small mono">72px</span>
-          </div>
-
-          <div class="btn-row">
-            <button id="obstacleBtn" class="ghost">Obstacle Mode: OFF</button>
-            <button id="clearObsBtn" class="ghost">Clear Obstacles</button>
-          </div>
-
-          <div class="btn-row" style="align-items:center">
-            <button id="terrainBtn" class="ghost">Terrain Mode: OFF</button>
-            <select id="terrainType">
-              <option value="plain">Plain</option>
-              <option value="forest">Forest (+2 DEF, cost 2)</option>
-              <option value="hill">Hill (+2 ATK, cost 2)</option>
-              <option value="road">Road (cost 1)</option>
-              <option value="swamp">Swamp (-2 ATK, cost 3)</option>
-              <option value="water">Water (impassable)</option>
-            </select>
-          </div>
-
-          <div class="legend">
-            <div class="lg"><span class="dot t-forest"></span>Forest</div>
-            <div class="lg"><span class="dot t-hill"></span>Hill</div>
-            <div class="lg"><span class="dot t-road"></span>Road</div>
-            <div class="lg"><span class="dot t-swamp"></span>Swamp</div>
-            <div class="lg"><span class="dot t-water"></span>Water</div>
-          </div>
-
-          <div class="divider"></div>
-          <div class="btn-row">
-            <button id="presetBtn" class="ghost">Preset: Bridge Clash</button>
-            <button id="fromSelectorBtn" class="ghost">Preset: From Selector</button>
-            <button id="clearBtn" class="ghost">Clear Units</button>
-            <button id="startBtn" class="primary">Start Battle</button>
-          </div>
-        </div>
-      </section>
-
       <section class="panel" id="partyPanel" style="display:none">
         <h2>Allies</h2>
         <div id="partyList"></div>
@@ -1281,13 +1302,13 @@ function initiativeOrder(){ return G.units.filter(u=>!u.dead).slice().sort((a,b)
 const BOARD=document.getElementById('board');
 const PHASE=document.getElementById('phaseTitle');
 const BOARD_HINT=document.getElementById('boardHint');
-const SETUP_PANEL=document.getElementById('setupPanel');
 const PARTY_PANEL=document.getElementById('partyPanel');
 const ENEMY_PANEL=document.getElementById('enemyPanel');
 const resetBtn=document.getElementById('resetBtn');
-const setupToggle=document.getElementById('setupToggle');
-const setupToggleLabel=setupToggle.querySelector('.toggle-label');
-const setupContent=document.getElementById('setupContent');
+const quickSetupBtn=document.getElementById('quickSetupBtn');
+const setupDropdown=document.getElementById('setupDropdown');
+const setupBackdrop=document.getElementById('setupBackdrop');
+const setupCloseBtn=document.getElementById('setupCloseBtn');
 
 const PARTY=document.getElementById('partyList');
 const ENEMIES=document.getElementById('enemyList');
@@ -1359,16 +1380,40 @@ const clearObsBtn=document.getElementById('clearObsBtn');
 const terrainBtn=document.getElementById('terrainBtn');
 const terrainType=document.getElementById('terrainType');
 
-function setSetupCollapsed(collapsed){
-  SETUP_PANEL.classList.toggle('collapsed', collapsed);
-  setupContent.hidden = collapsed;
-  setupToggle.setAttribute('aria-expanded', (!collapsed).toString());
-  setupToggleLabel.textContent = collapsed ? 'Expand' : 'Collapse';
+let setupOpen=false;
+function setSetupOpen(open){
+  if(!setupDropdown || !setupBackdrop){
+    setupOpen=false;
+    quickSetupBtn?.classList.remove('active');
+    quickSetupBtn?.setAttribute('aria-expanded','false');
+    return;
+  }
+  const allowOpen = open && G.phase === 'setup';
+  setupOpen = allowOpen;
+  if(allowOpen){
+    setupDropdown.hidden=false;
+    setupBackdrop.hidden=false;
+    quickSetupBtn?.classList.add('active');
+    quickSetupBtn?.setAttribute('aria-expanded','true');
+    setTimeout(()=>setupCloseBtn?.focus(), 0);
+  } else {
+    setupDropdown.hidden=true;
+    setupBackdrop.hidden=true;
+    quickSetupBtn?.classList.remove('active');
+    quickSetupBtn?.setAttribute('aria-expanded','false');
+  }
 }
 
-setupToggle.addEventListener('click', ()=>{
-  const collapsed = SETUP_PANEL.classList.contains('collapsed');
-  setSetupCollapsed(!collapsed);
+quickSetupBtn?.addEventListener('click', ()=>{
+  setSetupOpen(!setupOpen);
+});
+
+setupBackdrop?.addEventListener('click', ()=>setSetupOpen(false));
+setupCloseBtn?.addEventListener('click', ()=>setSetupOpen(false));
+document.addEventListener('keydown', (ev)=>{
+  if(ev.key==='Escape' && setupOpen){
+    setSetupOpen(false);
+  }
 });
 
 /* ========= Build buttons ========= */
@@ -1467,7 +1512,7 @@ function resetBoardState(){
   ABILROW.innerHTML='';
   LOG.innerHTML='';
   BOARD_HINT.innerHTML='';
-  setSetupCollapsed(true);
+  setSetupOpen(false);
   syncGridControls();
   renderBuildButtons();
   render();
@@ -1489,9 +1534,9 @@ function render(){
   fitBoardCellToPanel();
 
   if(G.phase==="setup"){
-    SETUP_PANEL.style.display="";
     PARTY_PANEL.style.display="none";
     ENEMY_PANEL.style.display="none";
+    if(quickSetupBtn){ quickSetupBtn.disabled=false; }
     ATTACK.disabled=ABILITY.disabled=DEFEND.disabled=MOVE.disabled=END.disabled=true;
     AUTO.disabled=true;
     AUTO.textContent="Auto-Play";
@@ -1506,7 +1551,8 @@ function render(){
       navAutoBtn.classList.remove('primary');
     }
   }else{
-    SETUP_PANEL.style.display="none";
+    setSetupOpen(false);
+    if(quickSetupBtn){ quickSetupBtn.disabled=true; }
     PARTY_PANEL.style.display="";
     ENEMY_PANEL.style.display="";
     // reflect Auto state
@@ -2033,7 +2079,7 @@ function aiAct(){
 (function preloadSprites(){ Object.values(SPRITES).forEach(src=>{ if(!src) return; const i=new Image(); i.src=src; }); })();
 (function boot(){
   renderBuildButtons();
-  setSetupCollapsed(true);
+  setSetupOpen(false);
   render();
   syncGridControls();
 })();


### PR DESCRIPTION
## Summary
- replace the sidebar quick setup panel with a header dropdown so it no longer occupies the side column
- add styles for the overlay, backdrop, and trigger button, keeping the quick setup controls scrollable on smaller screens
- update scripts to manage the dropdown state, close on escape/outside clicks, and disable the trigger while battles are running

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68d58ce9c4708324ad23c21437dcee6d