### PR TITLE
Improve quick start dropdown visibility

### DIFF
--- a/game-setup.html
+++ b/game-setup.html
@@ -303,17 +303,59 @@
       box-shadow:0 10px 18px rgba(14,26,24,.38);
     }
     label { font-size:12px; color:var(--muted); display:flex; flex-direction:column; gap:6px; }
-    input[type="text"], input[type="number"], select, textarea {
-      padding:9px 11px;
-      background:#0f1420;
+    input[type="text"], input[type="number"] {
+      padding:10px 12px;
+      background:linear-gradient(160deg, rgba(17,23,37,.95), rgba(10,14,25,.92));
       color:#fff;
-      border:1px solid rgba(42,50,70,.85);
+      border:1px solid rgba(68,96,146,.7);
       border-radius:10px;
       box-shadow:0 8px 16px rgba(0,0,0,.25) inset;
       font-size:13px;
       resize:vertical;
+      transition:border-color .18s ease, box-shadow .18s ease;
     }
-    textarea { min-height:68px; }
+    input[type="text"]:focus-visible,
+    input[type="number"]:focus-visible,
+    textarea:focus-visible {
+      outline:none;
+      border-color:rgba(127,230,162,.9);
+      box-shadow:0 0 0 1px rgba(127,230,162,.35), 0 12px 24px rgba(16,38,40,.45);
+    }
+    select {
+      appearance:none;
+      padding:12px 40px 12px 14px;
+      min-height:42px;
+      background:linear-gradient(160deg, rgba(18,26,44,.96), rgba(13,18,32,.94));
+      color:#fff;
+      border:1px solid rgba(74,108,166,.75);
+      border-radius:12px;
+      box-shadow:0 10px 20px rgba(0,0,0,.28) inset;
+      font-weight:500;
+      letter-spacing:.01em;
+      transition:border-color .18s ease, box-shadow .18s ease;
+      cursor:pointer;
+      background-image:url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12 8"><path fill="%237fe6a2" d="M1.3.7 6 5.4 10.7.7 12 2 6 8 0 2z"/></svg>');
+      background-repeat:no-repeat;
+      background-size:14px 10px;
+      background-position:right 14px center;
+    }
+    select:focus-visible {
+      outline:none;
+      border-color:rgba(127,230,162,.9);
+      box-shadow:0 0 0 1px rgba(127,230,162,.35), 0 14px 28px rgba(18,44,40,.45);
+    }
+    select:hover { border-color:rgba(127,230,162,.75); }
+    textarea {
+      min-height:68px;
+      padding:12px 14px;
+      background:linear-gradient(160deg, rgba(17,23,37,.95), rgba(10,14,25,.92));
+      color:#fff;
+      border:1px solid rgba(68,96,146,.7);
+      border-radius:12px;
+      box-shadow:0 8px 16px rgba(0,0,0,.25) inset;
+      transition:border-color .18s ease, box-shadow .18s ease;
+      resize:vertical;
+    }
     .form-row {
       display:flex;
       gap:14px;

--- a/index.html
+++ b/index.html
@@ -645,13 +645,46 @@
   .toast .heal { color:#86f7b9; font-weight:600; }
   .toast .hit { color:#facc15; font-weight:600; }
 
-  input[type="number"], select, input[type="text"] {
-    padding:8px 10px;
-    background:#0f1420;
+  input[type="number"], input[type="text"] {
+    padding:10px 12px;
+    background:linear-gradient(160deg, rgba(17,23,37,.95), rgba(10,14,25,.92));
     color:#fff;
-    border:1px solid rgba(42,50,70,.85);
+    border:1px solid rgba(68,96,146,.7);
     border-radius:10px;
     box-shadow:0 8px 16px rgba(0,0,0,.25) inset;
+    transition:border-color .18s ease, box-shadow .18s ease;
+  }
+  input[type="number"]:focus-visible,
+  input[type="text"]:focus-visible {
+    outline:none;
+    border-color:rgba(127,230,162,.9);
+    box-shadow:0 0 0 1px rgba(127,230,162,.35), 0 12px 24px rgba(16,38,40,.45);
+  }
+  select {
+    appearance:none;
+    padding:12px 40px 12px 14px;
+    min-height:42px;
+    background:linear-gradient(160deg, rgba(18,26,44,.96), rgba(13,18,32,.94));
+    color:#fff;
+    border:1px solid rgba(74,108,166,.75);
+    border-radius:12px;
+    box-shadow:0 10px 20px rgba(0,0,0,.28) inset;
+    font-weight:500;
+    letter-spacing:.01em;
+    transition:border-color .18s ease, box-shadow .18s ease;
+    cursor:pointer;
+    background-image:url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12 8"><path fill="%237fe6a2" d="M1.3.7 6 5.4 10.7.7 12 2 6 8 0 2z"/></svg>');
+    background-repeat:no-repeat;
+    background-size:14px 10px;
+    background-position:right 14px center;
+  }
+  select:focus-visible {
+    outline:none;
+    border-color:rgba(127,230,162,.9);
+    box-shadow:0 0 0 1px rgba(127,230,162,.35), 0 14px 28px rgba(18,44,40,.45);
+  }
+  select:hover {
+    border-color:rgba(127,230,162,.75);
   }
   input[type="number"] { width:64px; }
   input[type="range"] {
@@ -665,32 +698,86 @@
 
   .btn-row + .divider { margin-top:16px; }
 
-  #buildRow { gap:12px; }
-  #buildRow .buildBtn {
+  .quickstart-header {
     display:flex;
     align-items:center;
-    gap:10px;
-    padding:10px 14px;
-    border-radius:12px;
-    border:1px solid rgba(48,58,92,.8);
-    background:rgba(16,22,38,.85);
-    min-width:150px;
-    justify-content:flex-start;
+    justify-content:space-between;
+    margin:4px 0 8px;
+    gap:12px;
   }
+  .quickstart-title {
+    font-size:12px;
+    letter-spacing:.18em;
+    text-transform:uppercase;
+    color:#fff;
+  }
+  .quickstart-hint {
+    color:var(--muted);
+  }
+  #buildRow {
+    display:grid;
+    grid-template-columns:repeat(auto-fit, minmax(180px,1fr));
+    gap:14px;
+    margin-bottom:8px;
+  }
+  #buildRow .buildBtn {
+    display:flex;
+    flex-direction:column;
+    align-items:flex-start;
+    gap:10px;
+    padding:14px 16px;
+    border-radius:14px;
+    border:1px solid rgba(54,68,110,.85);
+    background:linear-gradient(160deg, rgba(18,24,42,.92), rgba(12,16,28,.94));
+    min-height:120px;
+    text-align:left;
+    position:relative;
+    overflow:hidden;
+    transition:transform .18s ease, border-color .18s ease, box-shadow .18s ease;
+  }
+  #buildRow .buildBtn::after {
+    content:"";
+    position:absolute;
+    inset:auto -40% -55% -40%;
+    height:70%;
+    background:radial-gradient(circle, rgba(127,230,162,.18) 0%, transparent 70%);
+    opacity:0;
+    transition:opacity .18s ease;
+    pointer-events:none;
+  }
+  #buildRow .buildBtn:hover {
+    border-color:rgba(127,230,162,.6);
+    transform:translateY(-2px);
+    box-shadow:0 14px 26px rgba(12,22,28,.45);
+  }
+  #buildRow .buildBtn:hover::after { opacity:1; }
   #buildRow .buildBtn .buildSprite {
-    width:42px;
-    height:42px;
-    border-radius:10px;
-    border:1px solid rgba(72,92,140,.6);
+    width:48px;
+    height:48px;
+    border-radius:12px;
+    border:1px solid rgba(80,104,158,.7);
     background-size:cover;
     background-position:center;
-    box-shadow:0 6px 14px rgba(0,0,0,.35);
+    box-shadow:0 6px 16px rgba(0,0,0,.35);
   }
-  #buildRow .buildBtn .buildLabel { font-weight:600; }
+  #buildRow .buildBtn .buildLabel {
+    font-weight:600;
+    font-size:15px;
+    color:#fff;
+  }
+  #buildRow .buildBtn .buildMeta {
+    font-size:12px;
+    color:var(--muted);
+    letter-spacing:.05em;
+  }
   #buildRow .buildBtn.primary {
-    border-color:rgba(127,230,162,.85);
-    box-shadow:0 12px 24px rgba(20,44,48,.45);
-    background:linear-gradient(135deg, rgba(24,38,58,.95), rgba(26,54,64,.9));
+    border-color:rgba(127,230,162,.9);
+    box-shadow:0 18px 30px rgba(20,44,48,.5);
+    background:linear-gradient(135deg, rgba(26,40,60,.96), rgba(28,56,66,.94));
+  }
+  #buildRow .buildBtn.primary::after {
+    opacity:1;
+    background:radial-gradient(circle, rgba(127,230,162,.26) 0%, transparent 72%);
   }
 
   .turnbar .pill { position:relative; padding-left:26px; }
@@ -759,7 +846,11 @@
         <label><input type="radio" name="team" value="enemy"> Enemies</label>
       </div>
 
-      <div class="btn-row" id="buildRow"></div>
+      <div class="quickstart-header">
+        <span class="quickstart-title">Quick Start Builds</span>
+        <span class="quickstart-hint small">Pick a template to instantly load party units</span>
+      </div>
+      <div id="buildRow"></div>
 
       <div class="divider"></div>
 
@@ -1217,6 +1308,7 @@ const UnitTemplates = Object.fromEntries(CLASS_ENTRIES.map(entry=>{
   return [entry.name, {
     label: entry.name,
     name: window.FABLE_DATA.defaultNameFor(entry.name),
+    role: entry.category,
     stats:{ maxHp: derived.maxHp, atk: derived.atk, def: derived.def, spd: derived.spd },
     abilities,
     range: derived.range,
@@ -1424,14 +1516,22 @@ function renderBuildButtons(){
     const b=document.createElement('button');
     b.type='button';
     b.className = 'buildBtn' + (key===activeBuild ? ' primary' : '');
+    b.setAttribute('aria-pressed', key===activeBuild ? 'true' : 'false');
+    const template = UnitTemplates[key];
+    const roleLabel = template.role || 'Adventurer';
+    const rangeLabel = template.range > 1 ? 'Ranged' : 'Melee';
+    b.title = `${template.label} (${roleLabel}) – ${rangeLabel} unit with SPD ${template.stats.spd}`;
     const sprite=document.createElement('span');
     sprite.className='buildSprite';
     const spriteUrl = SPRITES[key] || '';
     if(spriteUrl) sprite.style.backgroundImage = `url(${spriteUrl})`;
     const label=document.createElement('span');
     label.className='buildLabel';
-    label.textContent=UnitTemplates[key].label;
-    b.append(sprite,label);
+    label.textContent=template.label;
+    const meta=document.createElement('span');
+    meta.className='buildMeta';
+    meta.textContent = `${roleLabel} • ${rangeLabel} • SPD ${template.stats.spd}`;
+    b.append(sprite,label,meta);
     b.onclick=()=>{ activeBuild=key; renderBuildButtons(); renderBoard(); };
     buildRow.appendChild(b);
   });


### PR DESCRIPTION
## Summary
- restyle dropdown controls with higher-contrast gradients, accent hover states, and clearer focus outlines
- highlight quick start templates with a dedicated heading, grid layout, and additional role metadata for each option

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d5b7a4a27083249032424bc456756a