### PR TITLE
Adjust layout to elevate combat log

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,8 +97,8 @@
     gap:22px;
     grid-template-columns: minmax(0, 0.75fr) minmax(0, 1.7fr) minmax(0, 0.85fr);
     grid-template-areas:
-      "actions board side"
-      "actions board log";
+      "actions board log"
+      "actions board side";
     align-items:start;
     position:relative;
   }
@@ -811,9 +811,9 @@
       grid-template-columns: 1fr;
       grid-template-areas:
         "board"
+        "log"
         "actions"
-        "side"
-        "log";
+        "side";
       padding:24px 18px 48px;
       gap:18px;
     }


### PR DESCRIPTION
## Summary
- move the combat log into the top row of the main layout so it stays visible during battles
- update the responsive grid order to surface the log earlier on narrow screens as well

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d5c59a25e08324bc95501d2bbed4bf