### PR TITLE
Improve responsive nav and board scaling

### DIFF
--- a/game-setup.html
+++ b/game-setup.html
@@ -56,6 +56,13 @@
       align-items:center;
       gap:24px;
       backdrop-filter:blur(12px);
+      transition:padding .24s ease, background .24s ease, border-color .24s ease;
+    }
+    header.is-condensed {
+      padding:12px 18px;
+      gap:16px;
+      border-bottom-color:rgba(94,129,244,.18);
+      background:linear-gradient(135deg, rgba(16,22,38,.96), rgba(10,13,22,.95));
     }
     header h1 {
       margin:0;
@@ -64,6 +71,13 @@
       letter-spacing:.55px;
       text-transform:uppercase;
       flex:1;
+    }
+    header.is-condensed h1 {
+      font-size:16px;
+      letter-spacing:.42px;
+      white-space:nowrap;
+      overflow:hidden;
+      text-overflow:ellipsis;
     }
     nav {
       display:flex;
@@ -587,21 +601,66 @@
           "builder"
           "details"
           "library";
+        padding:24px 20px 52px;
+        gap:20px;
       }
+      .panel { padding:16px; }
+      .panel-lead { flex-direction:column; align-items:flex-start; }
+    }
+    @media (max-width: 900px) {
+      header {
+        flex-wrap:wrap;
+        align-items:flex-start;
+        gap:16px;
+        padding:16px 20px;
+      }
+      header h1 { flex:1 0 100%; }
+      nav {
+        width:100%;
+        flex-wrap:wrap;
+        gap:8px;
+        justify-content:flex-start;
+      }
+      header.is-condensed {
+        flex-wrap:nowrap;
+        align-items:center;
+        padding:12px 18px;
+        gap:14px;
+      }
+      header.is-condensed h1 { flex:0 1 auto; }
+      header.is-condensed nav {
+        width:auto;
+        flex:1 1 auto;
+        flex-wrap:nowrap;
+        gap:10px;
+        overflow-x:auto;
+        padding-bottom:2px;
+        -webkit-overflow-scrolling:touch;
+        scrollbar-width:none;
+      }
+      header.is-condensed nav::-webkit-scrollbar { display:none; }
+      header.is-condensed nav a {
+        flex:0 0 auto;
+        padding:6px 10px;
+        font-size:11px;
+        letter-spacing:.1em;
+      }
+      nav a {
+        padding:7px 12px;
+        letter-spacing:.12em;
+      }
+      .metric-group { width:100%; }
     }
     @media (max-width: 720px) {
-      header {
-        flex-direction:column;
-        align-items:flex-start;
-        gap:12px;
-      }
-      nav { flex-wrap:wrap; }
-      .panel-lead { flex-direction:column; }
-      .metric-group { width:100%; }
-      .list-controls { flex-direction:column; align-items:stretch; }
+      main { padding:20px 16px 44px; gap:18px; }
+      .panel { padding:15px; }
+      .panel-copy { max-width:none; }
+      .metric-group { flex-direction:column; }
+      .list-controls { flex-direction:column; align-items:stretch; gap:10px; }
       .filter-chip-row { justify-content:space-between; }
       .unit-actions { flex-direction:row; }
       .unit-actions button { flex:1; }
+      .type-grid { grid-template-columns:repeat(auto-fit, minmax(180px,1fr)); }
     }
   </style>
 </head>
@@ -719,6 +778,35 @@
   </main>
   <script src="class-data.js"></script>
   <script>
+    const HEADER = document.querySelector('header');
+    const navCondenseMedia = window.matchMedia('(max-width: 900px)');
+    let headerCondenseRaf = 0;
+    function applyHeaderCondense(){
+      if(!HEADER) return;
+      if(!navCondenseMedia.matches){
+        HEADER.classList.remove('is-condensed');
+        return;
+      }
+      const shouldCondense = window.scrollY > 48;
+      HEADER.classList.toggle('is-condensed', shouldCondense);
+    }
+    function handleHeaderScroll(){
+      if(headerCondenseRaf) return;
+      headerCondenseRaf = requestAnimationFrame(()=>{
+        headerCondenseRaf = 0;
+        applyHeaderCondense();
+      });
+    }
+    if(HEADER){
+      window.addEventListener('scroll', handleHeaderScroll, {passive:true});
+      window.addEventListener('resize', applyHeaderCondense);
+      if(typeof navCondenseMedia.addEventListener === 'function'){
+        navCondenseMedia.addEventListener('change', applyHeaderCondense);
+      } else if(typeof navCondenseMedia.addListener === 'function'){
+        navCondenseMedia.addListener(applyHeaderCondense);
+      }
+      applyHeaderCondense();
+    }
     const CLASS_DATA = window.FABLE_DATA.CLASS_DATABASE.slice();
     const CLASS_LOOKUP = new Map(CLASS_DATA.map(entry => [entry.name, entry]));
     const UNIT_TYPES = [

--- a/index.html
+++ b/index.html
@@ -55,6 +55,13 @@
     display:flex;
     align-items:center;
     gap:18px;
+    transition:padding .24s ease, background .24s ease, border-color .24s ease;
+  }
+  header.is-condensed {
+    padding:12px 18px;
+    gap:12px;
+    border-bottom-color:rgba(94,129,244,.18);
+    background:linear-gradient(135deg, rgba(16,22,38,.96), rgba(10,13,22,.95));
   }
   header nav {
     display:flex;
@@ -88,6 +95,13 @@
     letter-spacing:.55px;
     text-transform:uppercase;
     flex:1;
+  }
+  header.is-condensed h1 {
+    font-size:15px;
+    letter-spacing:.4px;
+    white-space:nowrap;
+    overflow:hidden;
+    text-overflow:ellipsis;
   }
   main {
     max-width:min(1480px, 96vw);
@@ -201,12 +215,114 @@
     from { transform:translateY(-8px); opacity:0; }
     to { transform:translateY(0); opacity:1; }
   }
-  @media (max-width: 720px) {
+  @media (max-width: 1280px) {
+    main {
+      grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+      grid-template-areas:
+        "board board"
+        "actions side"
+        "log log";
+      padding:24px 20px 52px;
+    }
+    .log { max-height:none; }
+  }
+  @media (max-width: 960px) {
+    header {
+      flex-wrap:wrap;
+      align-items:flex-start;
+      gap:14px;
+    }
+    header h1 { flex:1 0 100%; }
+    header nav {
+      width:100%;
+      justify-content:flex-start;
+      flex-wrap:wrap;
+      gap:8px;
+    }
+    header.is-condensed {
+      flex-wrap:nowrap;
+      align-items:center;
+      gap:12px;
+    }
+    header.is-condensed h1 { flex:0 1 auto; }
+    header.is-condensed nav {
+      width:auto;
+      flex:1 1 auto;
+      flex-wrap:nowrap;
+      gap:10px;
+      overflow-x:auto;
+      padding-bottom:2px;
+      -webkit-overflow-scrolling:touch;
+      scrollbar-width:none;
+    }
+    header.is-condensed nav::-webkit-scrollbar { display:none; }
+    header.is-condensed nav a,
+    header.is-condensed nav button.nav-btn {
+      flex:0 0 auto;
+      padding:6px 10px;
+      font-size:11px;
+      letter-spacing:.1em;
+    }
+    header.is-condensed #resetBtn {
+      padding:8px 12px;
+      font-size:12px;
+    }
+    header nav a,
+    header nav button.nav-btn {
+      padding:7px 12px;
+      letter-spacing:.12em;
+    }
     .setup-dropdown {
-      left:12px;
-      right:12px;
+      top:74px;
+      left:18px;
+      right:18px;
       width:auto;
     }
+    main {
+      grid-template-columns:minmax(0, 1fr);
+      grid-template-areas:
+        "board"
+        "actions"
+        "side"
+        "log";
+      padding:22px 18px 46px;
+      gap:20px;
+    }
+    .side { gap:16px; }
+    .controls { gap:16px; }
+    .grid { --cell: 64px; gap:8px; padding:16px; }
+  }
+  @media (max-width: 720px) {
+    header { padding:16px 18px; }
+    main {
+      padding:20px 16px 42px;
+      gap:18px;
+    }
+    .panel { padding:14px; }
+    h2 { font-size:12px; }
+    h2::after { width:38px; }
+    .btn-row { flex-direction:column; width:100%; }
+    .btn-row button { width:100%; }
+    .targetRow { flex-direction:column; }
+    .targetRow > * { width:100%; }
+    .setup-dropdown {
+      left:14px;
+      right:14px;
+    }
+    .grid { --cell: 56px; gap:7px; padding:14px; }
+    .legend { gap:8px; }
+  }
+  @media (max-width: 520px) {
+    header nav a,
+    header nav button.nav-btn {
+      flex:1 1 calc(50% - 6px);
+      justify-content:center;
+      text-align:center;
+    }
+    .grid { --cell: 48px; gap:6px; padding:12px; }
+    .unit { flex-wrap:wrap; }
+    .unit .row { flex-direction:column; align-items:flex-start; gap:6px; }
+    .controls .btn-row { gap:8px; }
   }
   .board { grid-area:board; }
   .side { grid-area:side; display:grid; gap:18px; }
@@ -804,6 +920,25 @@
     gap:18px;
     padding:20px 20px 26px;
   }
+  .board-frame {
+    --board-scale:1;
+    position:relative;
+    width:100%;
+    display:flex;
+    justify-content:center;
+    align-items:flex-start;
+    overflow:visible;
+    transition:height .24s ease;
+  }
+  .board-frame.is-scaled {
+    overflow:hidden;
+  }
+  .board-scale {
+    display:inline-block;
+    transform-origin:top center;
+    transform:scale(var(--board-scale));
+    transition:transform .24s ease;
+  }
   .panel.board .legend { margin-top:6px; }
 
   @media (max-width: 1100px) {
@@ -912,7 +1047,11 @@
   <main>
     <section class="panel board">
       <h2 id="phaseTitle">Setup: Place Units & Terrain</h2>
-      <div id="board" class="grid"></div>
+      <div class="board-frame">
+        <div class="board-scale">
+          <div id="board" class="grid"></div>
+        </div>
+      </div>
       <div id="boardHint" class="small"></div>
     </section>
 
@@ -1401,6 +1540,7 @@ function initiativeOrder(){ return G.units.filter(u=>!u.dead).slice().sort((a,b)
 
 /* ========= DOM ========= */
 const BOARD=document.getElementById('board');
+const BOARD_FRAME=document.querySelector('.board-frame');
 const PHASE=document.getElementById('phaseTitle');
 const BOARD_HINT=document.getElementById('boardHint');
 const PARTY_PANEL=document.getElementById('partyPanel');
@@ -1440,9 +1580,67 @@ const gridHInput = document.getElementById('gridH');
 const applyGridBtn = document.getElementById('applyGridBtn');
 const zoomRange = document.getElementById('zoomRange');
 const zoomVal = document.getElementById('zoomVal');
+const HEADER = document.querySelector('header');
 
 function parsePx(value){
   return typeof value === 'string' ? parseFloat(value) || 0 : 0;
+}
+
+let boardScaleRaf=0;
+function applyBoardScale(){
+  if(!BOARD || !BOARD_FRAME) return;
+  BOARD_FRAME.classList.remove('is-scaled');
+  BOARD_FRAME.style.removeProperty('height');
+  BOARD_FRAME.style.removeProperty('--board-scale');
+
+  const boardWidth = BOARD.scrollWidth;
+  const boardHeight = BOARD.scrollHeight;
+  if(!boardWidth || !boardHeight) return;
+
+  const availableWidth = Math.max(0, BOARD_FRAME.clientWidth - 4);
+  if(!availableWidth) return;
+  const scale = Math.min(1, availableWidth / boardWidth);
+  if(scale < 0.999){
+    BOARD_FRAME.style.setProperty('--board-scale', scale.toFixed(3));
+    BOARD_FRAME.style.height = `${boardHeight * scale}px`;
+    BOARD_FRAME.classList.add('is-scaled');
+  }
+}
+function queueBoardScale(){
+  if(boardScaleRaf) cancelAnimationFrame(boardScaleRaf);
+  boardScaleRaf = requestAnimationFrame(()=>{
+    boardScaleRaf = 0;
+    applyBoardScale();
+  });
+}
+
+const navCondenseMedia = window.matchMedia('(max-width: 960px)');
+let headerCondenseRaf = 0;
+function applyHeaderCondense(){
+  if(!HEADER) return;
+  if(!navCondenseMedia.matches){
+    HEADER.classList.remove('is-condensed');
+    return;
+  }
+  const shouldCondense = window.scrollY > 48;
+  HEADER.classList.toggle('is-condensed', shouldCondense);
+}
+function handleHeaderScroll(){
+  if(headerCondenseRaf) return;
+  headerCondenseRaf = requestAnimationFrame(()=>{
+    headerCondenseRaf = 0;
+    applyHeaderCondense();
+  });
+}
+if(HEADER){
+  window.addEventListener('scroll', handleHeaderScroll, {passive:true});
+  window.addEventListener('resize', applyHeaderCondense);
+  if(typeof navCondenseMedia.addEventListener === 'function'){
+    navCondenseMedia.addEventListener('change', applyHeaderCondense);
+  } else if(typeof navCondenseMedia.addListener === 'function'){
+    navCondenseMedia.addListener(applyHeaderCondense);
+  }
+  applyHeaderCondense();
 }
 
 function fitBoardCellToPanel(updateControls = true){
@@ -1473,6 +1671,7 @@ function fitBoardCellToPanel(updateControls = true){
     zoomRange.value = applied;
     zoomVal.textContent = applied + 'px';
   }
+  queueBoardScale();
 }
 
 const obstacleBtn=document.getElementById('obstacleBtn');
@@ -1805,6 +2004,7 @@ function renderBoard(){
       BOARD.appendChild(cell);
     }
   }
+  queueBoardScale();
 }
 function renderToken(unit, inRangeIds){
   const token=document.createElement('div');

--- a/selector.html
+++ b/selector.html
@@ -47,6 +47,13 @@
       display:flex;
       align-items:center;
       gap:18px;
+      transition:padding .24s ease, background .24s ease, border-color .24s ease;
+    }
+    header.is-condensed {
+      padding:12px 18px;
+      gap:12px;
+      border-bottom-color:rgba(94,129,244,.18);
+      background:linear-gradient(135deg, rgba(16,22,38,.96), rgba(10,13,22,.95));
     }
     header h1 {
       margin:0;
@@ -55,6 +62,13 @@
       letter-spacing:.55px;
       text-transform:uppercase;
       flex:1;
+    }
+    header.is-condensed h1 {
+      font-size:15px;
+      letter-spacing:.4px;
+      white-space:nowrap;
+      overflow:hidden;
+      text-overflow:ellipsis;
     }
     header nav {
       display:flex;
@@ -338,6 +352,82 @@
       border-color:rgba(96,165,250,.45);
       color:#bfdbfe;
     }
+    @media (max-width: 1100px) {
+      main { grid-template-columns:1fr; padding:24px 20px 46px; }
+      .lists { grid-template-columns:1fr; }
+      .panel { padding:16px; }
+    }
+    @media (max-width: 820px) {
+      header {
+        flex-wrap:wrap;
+        align-items:flex-start;
+        gap:14px;
+      }
+      header h1 { flex:1 0 100%; }
+      header nav {
+        width:100%;
+        justify-content:flex-start;
+        flex-wrap:wrap;
+        gap:8px;
+      }
+      header.is-condensed {
+        flex-wrap:nowrap;
+        align-items:center;
+        gap:12px;
+        padding:12px 18px;
+      }
+      header.is-condensed h1 { flex:0 1 auto; }
+      header.is-condensed nav {
+        width:auto;
+        flex:1 1 auto;
+        flex-wrap:nowrap;
+        gap:10px;
+        overflow-x:auto;
+        padding-bottom:2px;
+        -webkit-overflow-scrolling:touch;
+        scrollbar-width:none;
+      }
+      header.is-condensed nav::-webkit-scrollbar { display:none; }
+      header.is-condensed nav a {
+        flex:0 0 auto;
+        padding:6px 10px;
+        font-size:11px;
+        letter-spacing:.1em;
+      }
+      header nav a {
+        padding:7px 12px;
+        letter-spacing:.12em;
+      }
+      .panel { padding:15px; }
+    }
+    @media (max-width: 680px) {
+      header { padding:16px 18px; }
+      main { padding:22px 16px 42px; gap:16px; }
+      .row { flex-direction:column; align-items:stretch; }
+      .col { width:100%; min-width:0; }
+      input[type="number"] { width:100%; }
+      .lists { gap:14px; }
+      .unitCard {
+        display:flex;
+        flex-wrap:wrap;
+        gap:10px;
+        padding:12px;
+      }
+      .unitCard .sprite { flex:0 0 56px; width:56px; height:56px; }
+      .unitCard > div:nth-of-type(2) { flex:1 1 calc(100% - 66px); }
+      .unitCard > div:last-child { flex:1 0 100%; }
+      .unitCard > div:last-child button { width:100%; }
+      .classGrid { grid-template-columns:repeat(auto-fit, minmax(200px, 1fr)); }
+    }
+    @media (max-width: 480px) {
+      main { padding:18px 14px 38px; }
+      h2 { font-size:12px; }
+      h2::after { width:36px; }
+      button { width:100%; }
+      .footer { flex-direction:column; align-items:flex-start; }
+      .footer button { width:100%; }
+      .classFilters { gap:6px; }
+    }
   </style>
 </head>
 <body>
@@ -444,6 +534,35 @@
 
 <script src="class-data.js"></script>
 <script>
+const HEADER = document.querySelector('header');
+const navCondenseMedia = window.matchMedia('(max-width: 820px)');
+let headerCondenseRaf = 0;
+function applyHeaderCondense(){
+  if(!HEADER) return;
+  if(!navCondenseMedia.matches){
+    HEADER.classList.remove('is-condensed');
+    return;
+  }
+  const shouldCondense = window.scrollY > 48;
+  HEADER.classList.toggle('is-condensed', shouldCondense);
+}
+function handleHeaderScroll(){
+  if(headerCondenseRaf) return;
+  headerCondenseRaf = requestAnimationFrame(()=>{
+    headerCondenseRaf = 0;
+    applyHeaderCondense();
+  });
+}
+if(HEADER){
+  window.addEventListener('scroll', handleHeaderScroll, {passive:true});
+  window.addEventListener('resize', applyHeaderCondense);
+  if(typeof navCondenseMedia.addEventListener === 'function'){
+    navCondenseMedia.addEventListener('change', applyHeaderCondense);
+  } else if(typeof navCondenseMedia.addListener === 'function'){
+    navCondenseMedia.addListener(applyHeaderCondense);
+  }
+  applyHeaderCondense();
+}
 const CLASS_ENTRIES = window.FABLE_DATA.CLASS_DATABASE;
 const CLASS_NAMES = CLASS_ENTRIES.map(entry=>entry.name);
 

--- a/unit-icons.html
+++ b/unit-icons.html
@@ -54,6 +54,15 @@
       top:0;
       z-index:4;
       box-shadow:0 10px 24px rgba(76,54,26,.22);
+      transition:padding .24s ease, background .24s ease, border-color .24s ease, box-shadow .24s ease;
+    }
+    header.is-condensed {
+      padding:16px 20px;
+      gap:14px;
+      border-bottom-width:2px;
+      border-bottom-color:rgba(60,39,20,.26);
+      background:linear-gradient(180deg, rgba(245,233,207,.96), rgba(228,206,164,.9));
+      box-shadow:0 12px 28px rgba(76,54,26,.24);
     }
     header h1 {
       margin:0;
@@ -62,6 +71,13 @@
       letter-spacing:.32em;
       text-transform:uppercase;
       color:var(--ink);
+    }
+    header.is-condensed h1 {
+      font-size:18px;
+      letter-spacing:.24em;
+      white-space:nowrap;
+      overflow:hidden;
+      text-overflow:ellipsis;
     }
     header nav {
       display:flex;
@@ -209,6 +225,71 @@
       color:rgba(74,56,34,.65);
     }
     svg .stroke { stroke:#2d1f0f; stroke-linecap:round; stroke-linejoin:round; }
+    @media (max-width: 960px) {
+      header {
+        flex-wrap:wrap;
+        align-items:flex-start;
+        gap:14px;
+      }
+      header h1 {
+        flex:1 0 100%;
+        font-size:20px;
+      }
+      header nav {
+        width:100%;
+        justify-content:flex-start;
+        flex-wrap:wrap;
+        gap:8px;
+      }
+      header.is-condensed {
+        flex-wrap:nowrap;
+        align-items:center;
+        gap:12px;
+        padding:14px 18px;
+      }
+      header.is-condensed h1 { flex:0 1 auto; }
+      header.is-condensed nav {
+        width:auto;
+        flex:1 1 auto;
+        flex-wrap:nowrap;
+        gap:10px;
+        overflow-x:auto;
+        padding-bottom:2px;
+        -webkit-overflow-scrolling:touch;
+        scrollbar-width:none;
+      }
+      header.is-condensed nav::-webkit-scrollbar { display:none; }
+      header.is-condensed nav a {
+        flex:0 0 auto;
+        padding:7px 10px;
+        font-size:11px;
+        letter-spacing:.14em;
+      }
+      header nav a {
+        padding:8px 12px;
+        letter-spacing:.16em;
+      }
+      main { padding:32px 22px 60px; }
+    }
+    @media (max-width: 680px) {
+      header { padding:18px 20px; }
+      main { padding:24px 18px 52px; }
+      .intro { font-size:15px; }
+      .icon-grid { gap:18px; }
+      header nav a {
+        flex:1 1 calc(50% - 8px);
+        text-align:center;
+      }
+      header.is-condensed nav a {
+        flex:0 0 auto;
+      }
+    }
+    @media (max-width: 500px) {
+      header nav a { flex:1 1 100%; }
+      .icon-grid { grid-template-columns:repeat(auto-fit, minmax(180px, 1fr)); }
+      .unit-card { padding:18px; }
+      .icon-wrap { width:128px; height:128px; padding:16px; }
+    }
   </style>
 </head>
 <body>
@@ -442,5 +523,37 @@
       </article>
     </section>
   </main>
+  <script>
+    (function(){
+      const header = document.querySelector('header');
+      const media = window.matchMedia('(max-width: 960px)');
+      let rafId = 0;
+      function applyCondense(){
+        if(!header) return;
+        if(!media.matches){
+          header.classList.remove('is-condensed');
+          return;
+        }
+        header.classList.toggle('is-condensed', window.scrollY > 48);
+      }
+      function handleScroll(){
+        if(rafId) return;
+        rafId = requestAnimationFrame(()=>{
+          rafId = 0;
+          applyCondense();
+        });
+      }
+      if(header){
+        window.addEventListener('scroll', handleScroll, {passive:true});
+        window.addEventListener('resize', applyCondense);
+        if(typeof media.addEventListener === 'function'){
+          media.addEventListener('change', applyCondense);
+        } else if(typeof media.addListener === 'function'){
+          media.addListener(applyCondense);
+        }
+        applyCondense();
+      }
+    })();
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add scroll-triggered header condensing for responsive navigation across the combat, setup, selector, and icon views
- wrap the combat board in a scaling frame that auto-fits the grid within smaller panels while keeping controls readable
- tweak responsive styles so condensed nav links scroll horizontally and control buttons resize cleanly on small screens

## Testing
- No automated tests were run (static HTML/CSS/JS changes)


------
https://chatgpt.com/codex/tasks/task_e_68d5c73154748324bbc86f6429a30702