### PR TITLE
Add responsive header compaction and board scaling polish

### DIFF
--- a/game-setup.html
+++ b/game-setup.html
@@ -56,6 +56,23 @@
       align-items:center;
       gap:24px;
       backdrop-filter:blur(12px);
+      transition:padding .22s ease, gap .22s ease, background .22s ease, border-color .22s ease, box-shadow .22s ease;
+    }
+    header.header--compact {
+      padding:12px 20px;
+      gap:18px;
+      border-bottom-color:rgba(94,129,244,.3);
+      background:linear-gradient(135deg, rgba(15,20,36,.95), rgba(10,13,24,.94));
+      box-shadow:0 10px 28px rgba(5,8,18,.42);
+    }
+    header.header--compact h1 {
+      font-size:16px;
+      letter-spacing:.44px;
+    }
+    header.header--compact nav { gap:12px; }
+    header.header--compact nav a {
+      padding:7px 10px;
+      letter-spacing:.12em;
     }
     header h1 {
       margin:0;
@@ -587,21 +604,54 @@
           "builder"
           "details"
           "library";
+        padding:24px 20px 52px;
+        gap:20px;
       }
+      .panel { padding:16px; }
+      .panel-lead { flex-direction:column; align-items:flex-start; }
+    }
+    @media (max-width: 900px) {
+      header {
+        flex-wrap:wrap;
+        align-items:flex-start;
+        gap:16px;
+        padding:16px 20px;
+      }
+      header h1 { flex:1 0 100%; }
+      nav {
+        width:100%;
+        flex-wrap:wrap;
+        gap:8px;
+        justify-content:flex-start;
+      }
+      nav a {
+        padding:7px 12px;
+        letter-spacing:.12em;
+      }
+      header.header--compact {
+        padding:10px 16px;
+        gap:10px;
+      }
+      header.header--compact nav { gap:6px; }
+      header.header--compact nav a {
+        flex:1 1 calc(50% - 6px);
+        justify-content:center;
+        padding:6px 10px;
+        font-size:11px;
+        letter-spacing:.1em;
+      }
+      .metric-group { width:100%; }
     }
     @media (max-width: 720px) {
-      header {
-        flex-direction:column;
-        align-items:flex-start;
-        gap:12px;
-      }
-      nav { flex-wrap:wrap; }
-      .panel-lead { flex-direction:column; }
-      .metric-group { width:100%; }
-      .list-controls { flex-direction:column; align-items:stretch; }
+      main { padding:20px 16px 44px; gap:18px; }
+      .panel { padding:15px; }
+      .panel-copy { max-width:none; }
+      .metric-group { flex-direction:column; }
+      .list-controls { flex-direction:column; align-items:stretch; gap:10px; }
       .filter-chip-row { justify-content:space-between; }
       .unit-actions { flex-direction:row; }
       .unit-actions button { flex:1; }
+      .type-grid { grid-template-columns:repeat(auto-fit, minmax(180px,1fr)); }
     }
   </style>
 </head>
@@ -719,6 +769,21 @@
   </main>
   <script src="class-data.js"></script>
   <script>
+    (function setupResponsiveHeader(){
+      const header = document.querySelector('header');
+      if(!header) return;
+      let compact = header.classList.contains('header--compact');
+      const threshold = 48;
+      const applyState = ()=>{
+        const shouldCondense = window.scrollY > threshold;
+        if(shouldCondense === compact) return;
+        compact = shouldCondense;
+        header.classList.toggle('header--compact', compact);
+      };
+      window.addEventListener('scroll', applyState, { passive:true });
+      applyState();
+    })();
+
     const CLASS_DATA = window.FABLE_DATA.CLASS_DATABASE.slice();
     const CLASS_LOOKUP = new Map(CLASS_DATA.map(entry => [entry.name, entry]));
     const UNIT_TYPES = [

--- a/index.html
+++ b/index.html
@@ -55,6 +55,24 @@
     display:flex;
     align-items:center;
     gap:18px;
+    transition:padding .22s ease, gap .22s ease, background .22s ease, border-color .22s ease, box-shadow .22s ease;
+  }
+  header.header--compact {
+    padding:12px 20px;
+    gap:14px;
+    border-bottom-color:rgba(94,129,244,.32);
+    background:linear-gradient(135deg, rgba(15,20,36,.95), rgba(10,13,24,.94));
+    box-shadow:0 10px 28px rgba(5,8,18,.45);
+  }
+  header.header--compact h1 {
+    font-size:16px;
+    letter-spacing:.42px;
+  }
+  header.header--compact nav { gap:10px; }
+  header.header--compact nav a,
+  header.header--compact nav button.nav-btn {
+    padding:7px 10px;
+    letter-spacing:.12em;
   }
   header nav {
     display:flex;
@@ -201,12 +219,99 @@
     from { transform:translateY(-8px); opacity:0; }
     to { transform:translateY(0); opacity:1; }
   }
-  @media (max-width: 720px) {
+  @media (max-width: 1280px) {
+    main {
+      grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+      grid-template-areas:
+        "board board"
+        "actions side"
+        "log log";
+      padding:24px 20px 52px;
+    }
+    .log { max-height:none; }
+  }
+  @media (max-width: 960px) {
+    header {
+      flex-wrap:wrap;
+      align-items:flex-start;
+      gap:14px;
+    }
+    header h1 { flex:1 0 100%; }
+    header nav {
+      width:100%;
+      justify-content:flex-start;
+      flex-wrap:wrap;
+      gap:8px;
+    }
+    header nav a,
+    header nav button.nav-btn {
+      padding:7px 12px;
+      letter-spacing:.12em;
+    }
+    header.header--compact {
+      padding:10px 16px;
+      gap:10px;
+    }
+    header.header--compact nav { gap:6px; }
+    header.header--compact nav a,
+    header.header--compact nav button.nav-btn {
+      flex:1 1 calc(50% - 6px);
+      justify-content:center;
+      padding:6px 10px;
+      font-size:11px;
+      letter-spacing:.1em;
+    }
     .setup-dropdown {
-      left:12px;
-      right:12px;
+      top:74px;
+      left:18px;
+      right:18px;
       width:auto;
     }
+    main {
+      grid-template-columns:minmax(0, 1fr);
+      grid-template-areas:
+        "board"
+        "actions"
+        "side"
+        "log";
+      padding:22px 18px 46px;
+      gap:20px;
+    }
+    .side { gap:16px; }
+    .controls { gap:16px; }
+    .grid { --cell-base:64; gap:8px; padding:16px; }
+  }
+  @media (max-width: 720px) {
+    header { padding:16px 18px; }
+    main {
+      padding:20px 16px 42px;
+      gap:18px;
+    }
+    .panel { padding:14px; }
+    h2 { font-size:12px; }
+    h2::after { width:38px; }
+    .btn-row { flex-direction:column; width:100%; }
+    .btn-row button { width:100%; }
+    .targetRow { flex-direction:column; }
+    .targetRow > * { width:100%; }
+    .setup-dropdown {
+      left:14px;
+      right:14px;
+    }
+    .grid { --cell-base:56; gap:7px; padding:14px; }
+    .legend { gap:8px; }
+  }
+  @media (max-width: 520px) {
+    header nav a,
+    header nav button.nav-btn {
+      flex:1 1 calc(50% - 6px);
+      justify-content:center;
+      text-align:center;
+    }
+    .grid { --cell-base:48; gap:6px; padding:12px; }
+    .unit { flex-wrap:wrap; }
+    .unit .row { flex-direction:column; align-items:flex-start; gap:6px; }
+    .controls .btn-row { gap:8px; }
   }
   .board { grid-area:board; }
   .side { grid-area:side; display:grid; gap:18px; }
@@ -396,7 +501,8 @@
   }
 
   .grid {
-    --cell: 72px;
+    --cell-base:72;
+    --cell: calc(var(--cell-base) * 1px);
     display:grid;
     grid-template-columns: repeat(var(--w), var(--cell));
     grid-template-rows: repeat(var(--h), var(--cell));
@@ -1475,6 +1581,24 @@ function fitBoardCellToPanel(updateControls = true){
   }
 }
 
+function setupResponsiveHeader(){
+  const header = document.querySelector('header');
+  if(!header) return;
+  let compact = header.classList.contains('header--compact');
+  const threshold = 48;
+  const applyState = ()=>{
+    const shouldCondense = window.scrollY > threshold;
+    if(shouldCondense === compact) return;
+    compact = shouldCondense;
+    header.classList.toggle('header--compact', compact);
+    if(typeof fitBoardCellToPanel === 'function'){
+      requestAnimationFrame(()=>fitBoardCellToPanel(false));
+    }
+  };
+  window.addEventListener('scroll', applyState, { passive:true });
+  applyState();
+}
+
 const obstacleBtn=document.getElementById('obstacleBtn');
 const clearObsBtn=document.getElementById('clearObsBtn');
 
@@ -2191,6 +2315,7 @@ function aiAct(){
   setSetupOpen(false);
   render();
   syncGridControls();
+  setupResponsiveHeader();
 })();
 </script>
 </body>

--- a/selector.html
+++ b/selector.html
@@ -47,6 +47,23 @@
       display:flex;
       align-items:center;
       gap:18px;
+      transition:padding .22s ease, gap .22s ease, background .22s ease, border-color .22s ease, box-shadow .22s ease;
+    }
+    header.header--compact {
+      padding:12px 20px;
+      gap:14px;
+      border-bottom-color:rgba(94,129,244,.32);
+      background:linear-gradient(135deg, rgba(15,20,36,.95), rgba(10,13,24,.94));
+      box-shadow:0 10px 28px rgba(5,8,18,.42);
+    }
+    header.header--compact h1 {
+      font-size:16px;
+      letter-spacing:.44px;
+    }
+    header.header--compact nav { gap:10px; }
+    header.header--compact nav a {
+      padding:7px 10px;
+      letter-spacing:.12em;
     }
     header h1 {
       margin:0;
@@ -338,6 +355,77 @@
       border-color:rgba(96,165,250,.45);
       color:#bfdbfe;
     }
+    @media (max-width: 1100px) {
+      main { grid-template-columns:1fr; padding:24px 20px 46px; }
+      .lists { grid-template-columns:1fr; }
+      .panel { padding:16px; }
+    }
+    @media (max-width: 820px) {
+      header {
+        flex-wrap:wrap;
+        align-items:flex-start;
+        gap:14px;
+      }
+      header h1 { flex:1 0 100%; }
+      header nav {
+        width:100%;
+        justify-content:flex-start;
+        flex-wrap:wrap;
+        gap:8px;
+      }
+      header nav a {
+        padding:7px 12px;
+        letter-spacing:.12em;
+      }
+      header.header--compact {
+        padding:10px 16px;
+        gap:10px;
+      }
+      header.header--compact nav { gap:6px; }
+      header.header--compact nav a {
+        flex:1 1 calc(50% - 6px);
+        justify-content:center;
+        padding:6px 10px;
+        font-size:11px;
+        letter-spacing:.1em;
+      }
+      .panel { padding:15px; }
+    }
+    @media (max-width: 680px) {
+      header { padding:16px 18px; }
+      header.header--compact { padding:9px 14px; }
+      header.header--compact nav a { flex:1 1 calc(50% - 6px); }
+      main { padding:22px 16px 42px; gap:16px; }
+      .row { flex-direction:column; align-items:stretch; }
+      .col { width:100%; min-width:0; }
+      input[type="number"] { width:100%; }
+      .lists { gap:14px; }
+      .unitCard {
+        display:flex;
+        flex-wrap:wrap;
+        gap:10px;
+        padding:12px;
+      }
+      .unitCard .sprite { flex:0 0 56px; width:56px; height:56px; }
+      .unitCard > div:nth-of-type(2) { flex:1 1 calc(100% - 66px); }
+      .unitCard > div:last-child { flex:1 0 100%; }
+      .unitCard > div:last-child button { width:100%; }
+      .classGrid { grid-template-columns:repeat(auto-fit, minmax(200px, 1fr)); }
+    }
+    @media (max-width: 480px) {
+      main { padding:18px 14px 38px; }
+      h2 { font-size:12px; }
+      h2::after { width:36px; }
+      button { width:100%; }
+      .footer { flex-direction:column; align-items:flex-start; }
+      .footer button { width:100%; }
+      .classFilters { gap:6px; }
+      header nav a,
+      header.header--compact nav a {
+        flex:1 1 100%;
+        text-align:center;
+      }
+    }
   </style>
 </head>
 <body>
@@ -444,6 +532,21 @@
 
 <script src="class-data.js"></script>
 <script>
+(function setupResponsiveHeader(){
+  const header = document.querySelector('header');
+  if(!header) return;
+  let compact = header.classList.contains('header--compact');
+  const threshold = 48;
+  const update = ()=>{
+    const shouldCondense = window.scrollY > threshold;
+    if(shouldCondense === compact) return;
+    compact = shouldCondense;
+    header.classList.toggle('header--compact', compact);
+  };
+  window.addEventListener('scroll', update, { passive:true });
+  update();
+})();
+
 const CLASS_ENTRIES = window.FABLE_DATA.CLASS_DATABASE;
 const CLASS_NAMES = CLASS_ENTRIES.map(entry=>entry.name);
 

--- a/unit-icons.html
+++ b/unit-icons.html
@@ -54,6 +54,23 @@
       top:0;
       z-index:4;
       box-shadow:0 10px 24px rgba(76,54,26,.22);
+      transition:padding .22s ease, gap .22s ease, background .22s ease, border-color .22s ease, box-shadow .22s ease;
+    }
+    header.header--compact {
+      padding:16px 20px;
+      gap:16px;
+      border-bottom-color:rgba(60,39,20,.24);
+      background:linear-gradient(180deg, rgba(238,223,194,.94), rgba(225,203,164,.9));
+      box-shadow:0 12px 26px rgba(76,54,26,.28);
+    }
+    header.header--compact h1 {
+      font-size:20px;
+      letter-spacing:.26em;
+    }
+    header.header--compact nav { gap:10px; }
+    header.header--compact nav a {
+      padding:7px 10px;
+      letter-spacing:.15em;
     }
     header h1 {
       margin:0;
@@ -209,6 +226,59 @@
       color:rgba(74,56,34,.65);
     }
     svg .stroke { stroke:#2d1f0f; stroke-linecap:round; stroke-linejoin:round; }
+    @media (max-width: 960px) {
+      header {
+        flex-wrap:wrap;
+        align-items:flex-start;
+        gap:14px;
+      }
+      header h1 {
+        flex:1 0 100%;
+        font-size:20px;
+      }
+      header nav {
+        width:100%;
+        justify-content:flex-start;
+        flex-wrap:wrap;
+        gap:8px;
+      }
+      header nav a {
+        padding:8px 12px;
+        letter-spacing:.16em;
+      }
+      header.header--compact {
+        padding:12px 16px;
+        gap:10px;
+      }
+      header.header--compact nav { gap:6px; }
+      header.header--compact nav a {
+        flex:1 1 calc(50% - 6px);
+        justify-content:center;
+        padding:6px 10px;
+        font-size:11px;
+        letter-spacing:.12em;
+      }
+      main { padding:32px 22px 60px; }
+    }
+    @media (max-width: 680px) {
+      header { padding:18px 20px; }
+      header.header--compact { padding:10px 14px; }
+      header.header--compact nav a { flex:1 1 calc(50% - 6px); }
+      main { padding:24px 18px 52px; }
+      .intro { font-size:15px; }
+      .icon-grid { gap:18px; }
+      header nav a {
+        flex:1 1 calc(50% - 8px);
+        text-align:center;
+      }
+    }
+    @media (max-width: 500px) {
+      header nav a,
+      header.header--compact nav a { flex:1 1 100%; }
+      .icon-grid { grid-template-columns:repeat(auto-fit, minmax(180px, 1fr)); }
+      .unit-card { padding:18px; }
+      .icon-wrap { width:128px; height:128px; padding:16px; }
+    }
   </style>
 </head>
 <body>
@@ -442,5 +512,21 @@
       </article>
     </section>
   </main>
+  <script>
+    (function setupResponsiveHeader(){
+      const header = document.querySelector('header');
+      if(!header) return;
+      let compact = header.classList.contains('header--compact');
+      const threshold = 48;
+      const update = ()=>{
+        const shouldCondense = window.scrollY > threshold;
+        if(shouldCondense === compact) return;
+        compact = shouldCondense;
+        header.classList.toggle('header--compact', compact);
+      };
+      window.addEventListener('scroll', update, { passive:true });
+      update();
+    })();
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- compact the combat board header on scroll while adjusting grid cell sizing so the board resizes cleanly on small viewports
- apply the scroll-driven header compaction styling to the setup, selector, and unit icon pages for consistent responsive navigation

## Testing
- Not run (static HTML/CSS/JS updates)


------
https://chatgpt.com/codex/tasks/task_e_68d5c73154748324bbc86f6429a30702