### PR TITLE
Display newest combat log entries first

### DIFF
--- a/index.html
+++ b/index.html
@@ -1708,7 +1708,13 @@ resetBtn.onclick=()=>{
 };
 
 /* ========= Rendering ========= */
-function log(msg){ const el=document.createElement('div'); el.className='toast'; el.innerHTML=msg; LOG.appendChild(el); LOG.scrollTop=LOG.scrollHeight; }
+function log(msg){
+  const el=document.createElement('div');
+  el.className='toast';
+  el.innerHTML=msg;
+  LOG.prepend(el);
+  LOG.scrollTop=0;
+}
 
 function render(){
   PHASE.textContent = G.phase==="setup" ? "Setup: Place Units & Terrain" : "Battle";


### PR DESCRIPTION
## Summary
- prepend new combat log messages so the latest update appears at the top of the list
- reset the log scroll position after adding a new entry to keep the newest message visible

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d5e5da39a88324a1794cd66e83dcfe