### PR TITLE
Expand quick start panel layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -90,15 +90,16 @@
     flex:1;
   }
   main {
-    max-width:min(1480px, 96vw);
+    max-width:min(1600px, 96vw);
     margin:0 auto;
     padding:26px 26px 60px;
     display:grid;
     gap:22px;
-    grid-template-columns: minmax(0, 0.75fr) minmax(0, 1.7fr) minmax(0, 0.85fr);
+    grid-template-columns:minmax(0, 1.15fr) minmax(0, 1.8fr) minmax(0, 1fr);
     grid-template-areas:
-      "actions board log"
-      "actions board side";
+      "quick board controls"
+      "quick board log"
+      "quick board side";
     align-items:start;
     position:relative;
   }
@@ -140,75 +141,24 @@
     pointer-events:none;
   }
   .panel:hover::after { opacity:1; }
-  .setup-dropdown {
-    position:fixed;
-    top:82px;
-    right:24px;
-    width:min(420px, calc(100% - 32px));
-    z-index:9;
-    animation:dropdownFade .18s ease-out;
-  }
-  .setup-dropdown[hidden] {
-    display:none;
-  }
-  .setup-dropdown .panel {
-    padding:18px 18px 22px;
-    max-height:min(78vh, 560px);
-    overflow:auto;
-  }
-  .setup-backdrop {
-    position:fixed;
-    inset:0;
-    background:rgba(3,6,15,.58);
-    backdrop-filter:blur(4px);
-    z-index:8;
-  }
-  .setup-backdrop[hidden] {
-    display:none;
-  }
-  .dropdown-header {
-    display:flex;
-    align-items:center;
-    gap:12px;
-    margin-bottom:12px;
-  }
-  .dropdown-header h2 {
-    margin:0;
-  }
-  .icon-btn {
-    margin-left:auto;
-    background:rgba(20,26,40,.85);
-    border:1px solid rgba(64,82,124,.75);
-    color:var(--muted);
-    border-radius:8px;
-    padding:4px 8px;
-    font-size:18px;
-    line-height:1;
-  }
-  .icon-btn:hover {
-    color:#fff;
-    border-color:rgba(114,153,255,.85);
-  }
-  .setup-dropdown .divider:first-of-type {
-    margin-top:4px;
-  }
   header nav button.nav-btn.active {
     color:#fff;
     border-color:rgba(127,230,162,.8);
     box-shadow:0 0 0 1px rgba(127,230,162,.22);
   }
-  @keyframes dropdownFade {
-    from { transform:translateY(-8px); opacity:0; }
-    to { transform:translateY(0); opacity:1; }
-  }
   @media (max-width: 1280px) {
     main {
-      grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+      grid-template-columns:minmax(0, 1fr) minmax(0, 1fr);
       grid-template-areas:
-        "board board"
-        "actions side"
+        "quick board"
+        "quick board"
+        "controls side"
         "log log";
       padding:24px 20px 52px;
+    }
+    .panel.quickstart {
+      position:static;
+      max-height:none;
     }
     .log { max-height:none; }
   }
@@ -230,17 +180,12 @@
       padding:7px 12px;
       letter-spacing:.12em;
     }
-    .setup-dropdown {
-      top:74px;
-      left:18px;
-      right:18px;
-      width:auto;
-    }
     main {
       grid-template-columns:minmax(0, 1fr);
       grid-template-areas:
+        "quick"
         "board"
-        "actions"
+        "controls"
         "side"
         "log";
       padding:22px 18px 46px;
@@ -263,10 +208,6 @@
     .btn-row button { width:100%; }
     .targetRow { flex-direction:column; }
     .targetRow > * { width:100%; }
-    .setup-dropdown {
-      left:14px;
-      right:14px;
-    }
     .grid { --cell: 56px; gap:7px; padding:14px; }
     .legend { gap:8px; }
   }
@@ -284,7 +225,7 @@
   }
   .board { grid-area:board; }
   .side { grid-area:side; display:grid; gap:18px; }
-  .controls { grid-area:actions; display:flex; flex-direction:column; gap:18px; align-items:stretch; }
+  .controls { grid-area:controls; display:flex; flex-direction:column; gap:18px; align-items:stretch; }
   .log { grid-area:log; max-height:340px; overflow:auto; background:rgba(10,13,22,.75); backdrop-filter:blur(8px); }
   h2 {
     margin:0 0 10px;
@@ -792,13 +733,118 @@
   .quickstart-hint {
     color:var(--muted);
   }
+  .quickstart-controls {
+    display:flex;
+    flex-direction:column;
+    gap:12px;
+    margin-bottom:14px;
+  }
+  .search-field {
+    position:relative;
+  }
+  .search-field input[type="search"] {
+    width:100%;
+    border-radius:12px;
+    border:1px solid rgba(60,74,118,.75);
+    background:rgba(12,16,28,.88);
+    color:#fff;
+    padding:10px 12px;
+    font-size:14px;
+    transition:border-color .18s ease, box-shadow .18s ease;
+  }
+  .search-field input[type="search"]:focus {
+    outline:none;
+    border-color:rgba(127,230,162,.85);
+    box-shadow:0 0 0 1px rgba(127,230,162,.28);
+  }
+  .sr-only {
+    position:absolute;
+    width:1px;
+    height:1px;
+    padding:0;
+    margin:-1px;
+    overflow:hidden;
+    clip:rect(0,0,0,0);
+    border:0;
+  }
+  .filter-stack {
+    display:flex;
+    flex-wrap:wrap;
+    gap:12px;
+  }
+  .filter-group {
+    display:flex;
+    flex-direction:column;
+    gap:6px;
+    padding:10px 12px;
+    border:1px solid rgba(54,68,110,.7);
+    border-radius:12px;
+    background:rgba(18,24,42,.78);
+    min-width:200px;
+  }
+  .filter-label {
+    text-transform:uppercase;
+    letter-spacing:.16em;
+    color:rgba(255,255,255,.7);
+    font-size:11px;
+  }
+  .chip-row {
+    display:flex;
+    flex-wrap:wrap;
+    gap:8px;
+  }
+  .chip {
+    padding:6px 12px;
+    border-radius:999px;
+    border:1px solid rgba(60,74,118,.75);
+    background:rgba(16,22,38,.76);
+    color:var(--muted);
+    font-size:12px;
+    letter-spacing:.05em;
+    text-transform:uppercase;
+    cursor:pointer;
+    transition:border-color .18s ease, color .18s ease, box-shadow .18s ease;
+  }
+  .chip:hover {
+    border-color:rgba(114,153,255,.8);
+    color:#fff;
+  }
+  .chip.active {
+    border-color:rgba(127,230,162,.8);
+    color:#fff;
+    box-shadow:0 0 0 1px rgba(127,230,162,.18);
+  }
   #buildRow {
+    display:flex;
+    flex-direction:column;
+    gap:18px;
+  }
+  .build-section {
+    display:flex;
+    flex-direction:column;
+    gap:12px;
+  }
+  .build-section-title {
+    font-size:12px;
+    letter-spacing:.22em;
+    text-transform:uppercase;
+    color:rgba(255,255,255,.75);
+  }
+  .build-grid {
     display:grid;
     grid-template-columns:repeat(auto-fit, minmax(180px,1fr));
     gap:14px;
-    margin-bottom:8px;
   }
-  #buildRow .buildBtn {
+  .build-empty {
+    padding:20px;
+    border-radius:12px;
+    background:rgba(12,16,28,.72);
+    border:1px solid rgba(54,68,110,.6);
+    color:var(--muted);
+    text-align:center;
+    font-size:13px;
+  }
+  .build-grid .buildBtn {
     display:flex;
     flex-direction:column;
     align-items:flex-start;
@@ -813,7 +859,7 @@
     overflow:hidden;
     transition:transform .18s ease, border-color .18s ease, box-shadow .18s ease;
   }
-  #buildRow .buildBtn::after {
+  .build-grid .buildBtn::after {
     content:"";
     position:absolute;
     inset:auto -40% -55% -40%;
@@ -823,13 +869,13 @@
     transition:opacity .18s ease;
     pointer-events:none;
   }
-  #buildRow .buildBtn:hover {
+  .build-grid .buildBtn:hover {
     border-color:rgba(127,230,162,.6);
     transform:translateY(-2px);
     box-shadow:0 14px 26px rgba(12,22,28,.45);
   }
-  #buildRow .buildBtn:hover::after { opacity:1; }
-  #buildRow .buildBtn .buildSprite {
+  .build-grid .buildBtn:hover::after { opacity:1; }
+  .build-grid .buildBtn .buildSprite {
     width:48px;
     height:48px;
     border-radius:12px;
@@ -838,22 +884,22 @@
     background-position:center;
     box-shadow:0 6px 16px rgba(0,0,0,.35);
   }
-  #buildRow .buildBtn .buildLabel {
+  .build-grid .buildBtn .buildLabel {
     font-weight:600;
     font-size:15px;
     color:#fff;
   }
-  #buildRow .buildBtn .buildMeta {
+  .build-grid .buildBtn .buildMeta {
     font-size:12px;
     color:var(--muted);
     letter-spacing:.05em;
   }
-  #buildRow .buildBtn.primary {
+  .build-grid .buildBtn.primary {
     border-color:rgba(127,230,162,.9);
     box-shadow:0 18px 30px rgba(20,44,48,.5);
     background:linear-gradient(135deg, rgba(26,40,60,.96), rgba(28,56,66,.94));
   }
-  #buildRow .buildBtn.primary::after {
+  .build-grid .buildBtn.primary::after {
     opacity:1;
     background:radial-gradient(circle, rgba(127,230,162,.26) 0%, transparent 72%);
   }
@@ -873,6 +919,7 @@
   }
 
   .panel.board {
+    grid-area:board;
     display:flex;
     flex-direction:column;
     gap:18px;
@@ -880,16 +927,51 @@
   }
   .panel.board .legend { margin-top:6px; }
 
+  .panel.quickstart {
+    grid-area:quick;
+    display:flex;
+    flex-direction:column;
+    gap:16px;
+    padding:22px 20px 26px;
+    position:sticky;
+    top:106px;
+    max-height:calc(100vh - 140px);
+    overflow:auto;
+  }
+  .panel.quickstart::-webkit-scrollbar { width:10px; }
+  .panel.quickstart::-webkit-scrollbar-thumb {
+    border-radius:999px;
+    background:rgba(60,74,118,.6);
+  }
+  .panel.quickstart::-webkit-scrollbar-thumb:hover { background:rgba(114,153,255,.7); }
+  .panel.quickstart.quickstart-highlight {
+    box-shadow:0 0 0 2px rgba(127,230,162,.45), 0 0 0 8px rgba(127,230,162,.12), 0 28px 40px rgba(8,24,24,.35);
+    transition:box-shadow .25s ease;
+  }
+
+  .quickstart-top {
+    display:flex;
+    flex-direction:column;
+    gap:6px;
+  }
+  .quickstart-top h2 { margin:0; }
+  .quickstart-description { color:var(--muted); }
+
   @media (max-width: 1100px) {
     main {
-      grid-template-columns: 1fr;
+      grid-template-columns:1fr;
       grid-template-areas:
+        "quick"
         "board"
+        "controls"
         "log"
-        "actions"
         "side";
       padding:24px 18px 48px;
       gap:18px;
+    }
+    .panel.quickstart {
+      position:static;
+      max-height:none;
     }
     .side { grid-template-columns:1fr; }
     .panel.board { padding:20px 18px 24px; }
@@ -905,7 +987,7 @@
   <header>
     <h1>Fable Tactics • Sprites + Terrain + A*</h1>
     <nav>
-      <button id="quickSetupBtn" class="nav-btn" type="button" aria-haspopup="true" aria-expanded="false" aria-controls="setupDropdown">Quick Start</button>
+      <button id="quickSetupBtn" class="nav-btn" type="button" aria-controls="setupPanel">Quick Start</button>
       <a href="game-setup.html">Game Setup</a>
       <a href="selector.html">Party Selector</a>
       <a href="unit-icons.html">Unit Icons</a>
@@ -914,14 +996,12 @@
     </nav>
     <button id="resetBtn" class="warn" type="button">Reset Board</button>
   </header>
-  <div id="setupBackdrop" class="setup-backdrop" hidden></div>
-  <div id="setupDropdown" class="setup-dropdown" role="dialog" aria-modal="true" aria-labelledby="setupHeading" hidden>
-    <section class="panel" id="setupPanel">
-      <div class="dropdown-header">
-        <h2 id="setupHeading">Quick Start</h2>
-        <button id="setupCloseBtn" class="icon-btn" type="button" aria-label="Close quick start"><span aria-hidden="true">×</span></button>
+  <main>
+    <section class="panel quickstart" id="setupPanel">
+      <div class="quickstart-top">
+        <h2>Quick Start</h2>
+        <p class="quickstart-description small">Choose build/team. Toggle obstacle or terrain painting. Water is impassable. Obstacles block LOS.</p>
       </div>
-      <div class="small">Choose build/team. Toggle obstacle or terrain painting. Water is impassable. Obstacles block LOS.</div>
       <div class="divider"></div>
 
       <div class="btn-row" style="margin-bottom:8px">
@@ -931,8 +1011,35 @@
 
       <div class="quickstart-header">
         <span class="quickstart-title">Quick Start Builds</span>
-        <span class="quickstart-hint small">Pick a template to instantly load party units</span>
+        <span class="quickstart-hint small">Search or filter to find the right party template</span>
       </div>
+
+      <div class="quickstart-controls">
+        <div class="search-field">
+          <label for="buildSearch" class="sr-only">Search builds</label>
+          <input id="buildSearch" type="search" placeholder="Search builds…" autocomplete="off">
+        </div>
+        <div class="filter-stack">
+          <div class="filter-group" role="group" aria-label="Filter by role">
+            <span class="filter-label small">Role</span>
+            <div class="chip-row">
+              <button type="button" class="chip active" data-role-filter="all">All</button>
+              <button type="button" class="chip" data-role-filter="Combat">Combat</button>
+              <button type="button" class="chip" data-role-filter="Support">Support</button>
+              <button type="button" class="chip" data-role-filter="Utility">Utility</button>
+            </div>
+          </div>
+          <div class="filter-group" role="group" aria-label="Filter by attack type">
+            <span class="filter-label small">Range</span>
+            <div class="chip-row">
+              <button type="button" class="chip active" data-range-filter="all">All</button>
+              <button type="button" class="chip" data-range-filter="melee">Melee</button>
+              <button type="button" class="chip" data-range-filter="ranged">Ranged</button>
+            </div>
+          </div>
+        </div>
+      </div>
+
       <div id="buildRow"></div>
 
       <div class="divider"></div>
@@ -982,8 +1089,7 @@
         <button id="startBtn" class="primary">Start Battle</button>
       </div>
     </section>
-  </div>
-  <main>
+
     <section class="panel board">
       <h2 id="phaseTitle">Setup: Place Units & Terrain</h2>
       <div id="board" class="grid"></div>
@@ -1481,9 +1587,7 @@ const PARTY_PANEL=document.getElementById('partyPanel');
 const ENEMY_PANEL=document.getElementById('enemyPanel');
 const resetBtn=document.getElementById('resetBtn');
 const quickSetupBtn=document.getElementById('quickSetupBtn');
-const setupDropdown=document.getElementById('setupDropdown');
-const setupBackdrop=document.getElementById('setupBackdrop');
-const setupCloseBtn=document.getElementById('setupCloseBtn');
+const quickstartPanel=document.getElementById('setupPanel');
 
 const PARTY=document.getElementById('partyList');
 const ENEMIES=document.getElementById('enemyList');
@@ -1502,6 +1606,9 @@ const TARGETS=document.getElementById('targetRow');
 const ABILROW=document.getElementById('abilityRow');
 
 const buildRow=document.getElementById('buildRow');
+const buildSearchInput = document.getElementById('buildSearch');
+const roleFilterButtons = [...document.querySelectorAll('[data-role-filter]')];
+const rangeFilterButtons = [...document.querySelectorAll('[data-range-filter]')];
 const presetBtn=document.getElementById('presetBtn');
 const fromSelectorBtn=document.getElementById('fromSelectorBtn');
 const clearBtn=document.getElementById('clearBtn');
@@ -1555,70 +1662,166 @@ const clearObsBtn=document.getElementById('clearObsBtn');
 const terrainBtn=document.getElementById('terrainBtn');
 const terrainType=document.getElementById('terrainType');
 
-let setupOpen=false;
+let setupHighlightTimeout;
 function setSetupOpen(open){
-  if(!setupDropdown || !setupBackdrop){
-    setupOpen=false;
-    quickSetupBtn?.classList.remove('active');
-    quickSetupBtn?.setAttribute('aria-expanded','false');
+  if(!open){
+    clearTimeout(setupHighlightTimeout);
+    quickstartPanel?.classList.remove('quickstart-highlight');
     return;
   }
-  const allowOpen = open && G.phase === 'setup';
-  setupOpen = allowOpen;
-  if(allowOpen){
-    setupDropdown.hidden=false;
-    setupBackdrop.hidden=false;
-    quickSetupBtn?.classList.add('active');
-    quickSetupBtn?.setAttribute('aria-expanded','true');
-    setTimeout(()=>setupCloseBtn?.focus(), 0);
-  } else {
-    setupDropdown.hidden=true;
-    setupBackdrop.hidden=true;
-    quickSetupBtn?.classList.remove('active');
-    quickSetupBtn?.setAttribute('aria-expanded','false');
+  if(G.phase !== 'setup' || !quickstartPanel){
+    return;
   }
+  quickstartPanel.classList.add('quickstart-highlight');
+  quickstartPanel.scrollIntoView({ behavior:'smooth', block:'start' });
+  clearTimeout(setupHighlightTimeout);
+  setupHighlightTimeout = window.setTimeout(()=>{
+    quickstartPanel?.classList.remove('quickstart-highlight');
+  }, 1200);
 }
 
 quickSetupBtn?.addEventListener('click', ()=>{
-  setSetupOpen(!setupOpen);
-});
-
-setupBackdrop?.addEventListener('click', ()=>setSetupOpen(false));
-setupCloseBtn?.addEventListener('click', ()=>setSetupOpen(false));
-document.addEventListener('keydown', (ev)=>{
-  if(ev.key==='Escape' && setupOpen){
-    setSetupOpen(false);
-  }
+  setSetupOpen(true);
 });
 
 /* ========= Build buttons ========= */
 let activeBuild="Knight";
-function renderBuildButtons(){
-  buildRow.innerHTML="";
-  Object.keys(UnitTemplates).forEach(key=>{
-    const b=document.createElement('button');
-    b.type='button';
-    b.className = 'buildBtn' + (key===activeBuild ? ' primary' : '');
-    b.setAttribute('aria-pressed', key===activeBuild ? 'true' : 'false');
-    const template = UnitTemplates[key];
-    const roleLabel = template.role || 'Adventurer';
-    const rangeLabel = template.range > 1 ? 'Ranged' : 'Melee';
-    b.title = `${template.label} (${roleLabel}) – ${rangeLabel} unit with SPD ${template.stats.spd}`;
-    const sprite=document.createElement('span');
-    sprite.className='buildSprite';
-    const spriteUrl = SPRITES[key] || '';
-    if(spriteUrl) sprite.style.backgroundImage = `url(${spriteUrl})`;
-    const label=document.createElement('span');
-    label.className='buildLabel';
-    label.textContent=template.label;
-    const meta=document.createElement('span');
-    meta.className='buildMeta';
-    meta.textContent = `${roleLabel} • ${rangeLabel} • SPD ${template.stats.spd}`;
-    b.append(sprite,label,meta);
-    b.onclick=()=>{ activeBuild=key; renderBuildButtons(); renderBoard(); };
-    buildRow.appendChild(b);
+let activeRoleFilter = 'all';
+let activeRangeFilter = 'all';
+let buildSearchTerm = '';
+
+function updateActiveChip(buttons, activeValue, attr){
+  buttons.forEach(btn=>{
+    const value = btn.getAttribute(attr);
+    if(value === activeValue){
+      btn.classList.add('active');
+      btn.setAttribute('aria-pressed','true');
+    } else {
+      btn.classList.remove('active');
+      btn.setAttribute('aria-pressed','false');
+    }
   });
 }
+
+function renderBuildButtons(){
+  buildRow.innerHTML="";
+  const searchTerm = buildSearchTerm.trim().toLowerCase();
+  const entries = Object.entries(UnitTemplates)
+    .map(([key, template])=>({ key, template }))
+    .sort((a,b)=>a.template.label.localeCompare(b.template.label));
+
+  const filtered = entries.filter(({template})=>{
+    const roleMatch = activeRoleFilter==='all' || template.role===activeRoleFilter;
+    const isRanged = (template.range ?? 1) > 1;
+    const rangeMatch = activeRangeFilter==='all'
+      || (activeRangeFilter==='ranged' && isRanged)
+      || (activeRangeFilter==='melee' && !isRanged);
+    let searchMatch = true;
+    if(searchTerm){
+      const haystack = [template.label, template.role, template.abilities?.join(' ') ?? '', template.attributes ? Object.keys(template.attributes).join(' ') : '']
+        .join(' ')
+        .toLowerCase();
+      searchMatch = haystack.includes(searchTerm);
+    }
+    return roleMatch && rangeMatch && searchMatch;
+  });
+
+  const groups = new Map();
+  filtered.forEach(entry=>{
+    const role = entry.template.role || 'Adventurer';
+    if(!groups.has(role)) groups.set(role, []);
+    groups.get(role).push(entry);
+  });
+
+  const order = ['Combat','Support','Utility'];
+  const sortedGroups = [...groups.entries()].sort((a,b)=>{
+    const ia = order.indexOf(a[0]);
+    const ib = order.indexOf(b[0]);
+    if(ia === -1 && ib === -1) return a[0].localeCompare(b[0]);
+    if(ia === -1) return 1;
+    if(ib === -1) return -1;
+    return ia - ib;
+  });
+
+  if(!sortedGroups.length){
+    const empty=document.createElement('div');
+    empty.className='build-empty';
+    empty.textContent='No builds match your filters. Try clearing the search or selecting a different role.';
+    buildRow.appendChild(empty);
+    return;
+  }
+
+  const showSectionTitles = activeRoleFilter==='all' || sortedGroups.length>1;
+
+  sortedGroups.forEach(([role, list])=>{
+    const section=document.createElement('div');
+    section.className='build-section';
+    if(showSectionTitles){
+      const title=document.createElement('h3');
+      title.className='build-section-title';
+      title.textContent=role;
+      section.appendChild(title);
+    }
+    const grid=document.createElement('div');
+    grid.className='build-grid';
+    list.forEach(({key, template})=>{
+      const b=document.createElement('button');
+      b.type='button';
+      b.className = 'buildBtn' + (key===activeBuild ? ' primary' : '');
+      b.setAttribute('aria-pressed', key===activeBuild ? 'true' : 'false');
+      const roleLabel = template.role || 'Adventurer';
+      const rangeLabel = (template.range ?? 1) > 1 ? 'Ranged' : 'Melee';
+      b.title = `${template.label} (${roleLabel}) – ${rangeLabel} unit with SPD ${template.stats.spd}`;
+      const sprite=document.createElement('span');
+      sprite.className='buildSprite';
+      const spriteUrl = SPRITES[key] || '';
+      if(spriteUrl) sprite.style.backgroundImage = `url(${spriteUrl})`;
+      const label=document.createElement('span');
+      label.className='buildLabel';
+      label.textContent=template.label;
+      const meta=document.createElement('span');
+      meta.className='buildMeta';
+      meta.textContent = `${roleLabel} • ${rangeLabel} • SPD ${template.stats.spd}`;
+      b.append(sprite,label,meta);
+      b.onclick=()=>{
+        activeBuild=key;
+        renderBuildButtons();
+        renderBoard();
+      };
+      grid.appendChild(b);
+    });
+    section.appendChild(grid);
+    buildRow.appendChild(section);
+  });
+}
+
+buildSearchInput?.addEventListener('input', (event)=>{
+  buildSearchTerm = event.target.value ?? '';
+  renderBuildButtons();
+});
+
+roleFilterButtons.forEach(btn=>{
+  btn.addEventListener('click', ()=>{
+    const next = btn.getAttribute('data-role-filter') || 'all';
+    if(activeRoleFilter === next) return;
+    activeRoleFilter = next;
+    updateActiveChip(roleFilterButtons, activeRoleFilter, 'data-role-filter');
+    renderBuildButtons();
+  });
+});
+
+rangeFilterButtons.forEach(btn=>{
+  btn.addEventListener('click', ()=>{
+    const next = btn.getAttribute('data-range-filter') || 'all';
+    if(activeRangeFilter === next) return;
+    activeRangeFilter = next;
+    updateActiveChip(rangeFilterButtons, activeRangeFilter, 'data-range-filter');
+    renderBuildButtons();
+  });
+});
+
+updateActiveChip(roleFilterButtons, activeRoleFilter, 'data-role-filter');
+updateActiveChip(rangeFilterButtons, activeRangeFilter, 'data-range-filter');
 function getSelectedTeam(){
   const radios=[...document.querySelectorAll('input[name="team"]')];
   const r=radios.find(x=>x.checked); return r? r.value : "ally";


### PR DESCRIPTION
## Summary
- move the quick start content into a persistent left-hand panel within the main layout
- adjust the grid and responsive styling so the quick start panel stays visible and scrollable on the left
- replace the dropdown toggle logic with a highlight/scroll cue when the quick start button is pressed

## Testing
- Not run (UI-only change)

------
https://chatgpt.com/codex/tasks/task_e_68d60281e9388324a1edd092a030bf99