### PR TITLE
Fix board reset clearing grid configuration

### DIFF
--- a/index.html
+++ b/index.html
@@ -2338,10 +2338,6 @@ function resetBoardState(){
   G.auto=false;
   G.obstacleMode=false;
   G.terrainMode=false;
-  GRID.w=8;
-  GRID.h=6;
-  GRID.cell=72;
-  GRID.desiredCell=72;
   GRID.obstacles.clear();
   GRID.terrain.clear();
   activeBuild="Knight";


### PR DESCRIPTION
## Summary
- stop `resetBoardState` from overwriting the current grid configuration
- ensure resetting the board keeps the existing layout instead of forcing the default rectangle

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d89be90d4c83248641ebbc06f9a331