### PR TITLE
Fix glyph mapping for Folk Companion

### DIFF
--- a/class-data.js
+++ b/class-data.js
@@ -477,7 +477,7 @@
     ,Runesmith:"🪨"
     ,Tailor:"🧵"
     ,Navigator:"🧭"
-    ,FolkCompanion:"🐕"
+    ,'Folk Companion':"🐕"
     ,Artificer:"🛠"
     ,Chronicler:"📝"
     ,Trapper:"🪤"


### PR DESCRIPTION
## Summary
- correct the glyph override key so Folk Companion uses its custom icon

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8b0665b148324ba4540965b838b0c