### PR TITLE
Stop auto-loading quick start scenario on main map

### DIFF
--- a/index.html
+++ b/index.html
@@ -914,6 +914,25 @@ const SPRITES = (()=>{
   }));
 })();
 
+const randomId = (()=>{
+  if(typeof crypto !== 'undefined'){
+    if(typeof crypto.randomUUID === 'function'){
+      return ()=>crypto.randomUUID();
+    }
+    if(typeof crypto.getRandomValues === 'function'){
+      return ()=>{
+        const bytes=new Uint8Array(16);
+        crypto.getRandomValues(bytes);
+        bytes[6]=(bytes[6]&0x0f)|0x40;
+        bytes[8]=(bytes[8]&0x3f)|0x80;
+        const hex=[...bytes].map(b=>b.toString(16).padStart(2,'0')).join('');
+        return `${hex.slice(0,8)}-${hex.slice(8,12)}-${hex.slice(12,16)}-${hex.slice(16,20)}-${hex.slice(20)}`;
+      };
+    }
+  }
+  return ()=>`unit-${Math.random().toString(36).slice(2,10)}-${Date.now().toString(36)}`;
+})();
+
 /* ========= Core / Grid ========= */
 const clamp=(v,min,max)=>Math.max(min,Math.min(max,v));
 const rand=(a,b)=>Math.floor(Math.random()*(b-a+1))+a;
@@ -1565,7 +1584,7 @@ const UnitTemplates = Object.fromEntries(CLASS_ENTRIES.map(entry=>{
 function makeUnit(tplKey, team, pos){
   const T = UnitTemplates[tplKey] || UnitTemplates.Knight;
   return {
-    id: crypto.randomUUID(),
+    id: randomId(),
     name: T.name, team, tplKey,
     stats: {...T.stats}, hp:T.stats.maxHp, dead:false,
     temp:{defBonus:0,defend:false,atkBuff:0,spdBuff:0,shield:0,quickdraw:false}, statuses:[],
@@ -1963,6 +1982,7 @@ clearObsBtn?.addEventListener('click', ()=>{ GRID.obstacles.clear(); render(); }
 
 function resetBoardState(){
   G.phase="setup";
+  scenarioHasLoaded=false;
   G.units=[];
   G.acting=null;
   G.round=1;
@@ -1992,10 +2012,9 @@ resetBtn?.addEventListener('click', ()=>{
     resetBoardState();
     return;
   }
-  const defaultScenario = activeScenarioKey || QUICK_SCENARIOS[0]?.key || null;
-  if(defaultScenario){
+  if(scenarioHasLoaded && activeScenarioKey){
     if(G.phase==='battle') G.phase='setup';
-    applyScenario(defaultScenario);
+    applyScenario(activeScenarioKey);
     startBattle();
   } else {
     resetBoardState();
@@ -2373,6 +2392,7 @@ const QUICK_SCENARIOS=[
 ];
 
 let activeScenarioKey=QUICK_SCENARIOS[0]?.key ?? null;
+let scenarioHasLoaded=false;
 
 function findScenario(key){
   return QUICK_SCENARIOS.find(s=>s.key===key) || null;
@@ -2487,19 +2507,13 @@ function applyScenario(key){
   render();
   setSetupOpen(true);
 
+  scenarioHasLoaded=true;
+
   if(presetSelect){ presetSelect.value=scenario.key; }
   updatePresetDescription();
 }
 
 populateScenarioOptions();
-
-if(!HAS_SETUP_PANEL){
-  const defaultScenario = activeScenarioKey || QUICK_SCENARIOS[0]?.key || null;
-  if(defaultScenario){
-    applyScenario(defaultScenario);
-    startBattle();
-  }
-}
 
 presetSelect?.addEventListener('change', ()=>{
   activeScenarioKey=presetSelect.value;

--- a/quickstart.html
+++ b/quickstart.html
@@ -1298,6 +1298,25 @@ const SPRITES = (()=>{
   }));
 })();
 
+const randomId = (()=>{
+  if(typeof crypto !== 'undefined'){
+    if(typeof crypto.randomUUID === 'function'){
+      return ()=>crypto.randomUUID();
+    }
+    if(typeof crypto.getRandomValues === 'function'){
+      return ()=>{
+        const bytes=new Uint8Array(16);
+        crypto.getRandomValues(bytes);
+        bytes[6]=(bytes[6]&0x0f)|0x40;
+        bytes[8]=(bytes[8]&0x3f)|0x80;
+        const hex=[...bytes].map(b=>b.toString(16).padStart(2,'0')).join('');
+        return `${hex.slice(0,8)}-${hex.slice(8,12)}-${hex.slice(12,16)}-${hex.slice(16,20)}-${hex.slice(20)}`;
+      };
+    }
+  }
+  return ()=>`unit-${Math.random().toString(36).slice(2,10)}-${Date.now().toString(36)}`;
+})();
+
 /* ========= Core / Grid ========= */
 const clamp=(v,min,max)=>Math.max(min,Math.min(max,v));
 const rand=(a,b)=>Math.floor(Math.random()*(b-a+1))+a;
@@ -1949,7 +1968,7 @@ const UnitTemplates = Object.fromEntries(CLASS_ENTRIES.map(entry=>{
 function makeUnit(tplKey, team, pos){
   const T = UnitTemplates[tplKey] || UnitTemplates.Knight;
   return {
-    id: crypto.randomUUID(),
+    id: randomId(),
     name: T.name, team, tplKey,
     stats: {...T.stats}, hp:T.stats.maxHp, dead:false,
     temp:{defBonus:0,defend:false,atkBuff:0,spdBuff:0,shield:0,quickdraw:false}, statuses:[],


### PR DESCRIPTION
## Summary
- keep the main battle map empty on load instead of automatically applying the default quick start scenario
- track whether a quick start preset has been loaded and only reapply it on reset after the user has chosen one

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d957791de88324b1a89da8db0357a3