### PR TITLE
Fix builder map mask alignment for combat sim

### DIFF
--- a/board-builder.html
+++ b/board-builder.html
@@ -385,8 +385,8 @@
       <div>
         <h2>Forge Your Battlefield</h2>
         <p>
-          Assemble bespoke tactical battlemaps in minutes. Sketch the terrain, mark hazards, and export the layout for use in the
-          combat simulator or your tabletop encounters.
+          Assemble bespoke hex battlemaps that line up with the combat simulator. Paint terrain using the shared rules vocabulary
+          (plain, forest, hill, road, swamp, water) and export ready-to-play JSON for the simulator or your tabletop encounters.
         </p>
       </div>
       <div class="board-tools">
@@ -420,7 +420,7 @@
         <div class="control-group">
           <h3>Import Map</h3>
           <label for="importInput">Paste exported JSON</label>
-          <textarea id="importInput" placeholder="Paste map data here…"></textarea>
+          <textarea id="importInput" placeholder="Paste Combat Sim or Battlemap Builder JSON…"></textarea>
           <div class="board-tools">
             <button type="button" id="importButton" class="secondary">Load Map</button>
           </div>
@@ -432,8 +432,8 @@
         </div>
         <div class="board-status">
           <div>Selected Terrain: <strong id="selectedTerrainLabel">—</strong></div>
-          <div>Hover: <strong id="hoverLabel">–</strong></div>
-          <div>Tiles Painted: <strong id="paintedCount">0</strong></div>
+          <div>Hover (Row/Col → Axial): <strong id="hoverLabel">–</strong></div>
+          <div>Hexes Painted: <strong id="paintedCount">0</strong></div>
         </div>
         <div class="control-group">
           <h3>Legend</h3>
@@ -447,14 +447,54 @@
     </section>
   </main>
   <script>
+    const terrainAliases = {
+      plain: 'plain',
+      plains: 'plain',
+      open: 'plain',
+      forest: 'forest',
+      woods: 'forest',
+      cover: 'forest',
+      hill: 'hill',
+      stone: 'hill',
+      rocky: 'hill',
+      road: 'road',
+      path: 'road',
+      trail: 'road',
+      swamp: 'swamp',
+      marsh: 'swamp',
+      hazard: 'swamp',
+      difficult: 'swamp',
+      water: 'water',
+      river: 'water'
+    };
+
+    function normalizeTerrainId(id, fallback = 'plain') {
+      if (!id) return fallback;
+      const safe = String(id).trim().toLowerCase();
+      if (!safe || safe === 'default' || safe === 'null' || safe === 'undefined' || safe === 'base') {
+        return fallback;
+      }
+      return terrainAliases[safe] || safe;
+    }
+
+    function offsetToAxial(col, row) {
+      const q = col;
+      const r = row - (col - (col & 1)) / 2;
+      return { q, r };
+    }
+
+    function formatAxial({ q, r }) {
+      const format = value => `${value >= 0 ? '+' : ''}${value}`;
+      return `q ${format(q)}, r ${format(r)}`;
+    }
+
     const defaultTerrains = [
-      { id: 'plains', name: 'Open Ground', color: '#f3e2c3', accent: '#d3b58a', label: 'P' },
-      { id: 'forest', name: 'Dense Forest', color: '#88a86b', accent: '#587147', label: 'F' },
-      { id: 'water', name: 'Water / River', color: '#6aa7c5', accent: '#3a6b84', label: 'W' },
-      { id: 'stone', name: 'Rocky Ridge', color: '#b7b5ae', accent: '#6e6b65', label: 'R' },
-      { id: 'hazard', name: 'Hazard / Trap', color: '#d27452', accent: '#8f3b22', label: 'H' },
-      { id: 'cover', name: 'Half Cover', color: '#d6c47d', accent: '#9f8541', label: 'C' },
-      { id: 'difficult', name: 'Difficult Ground', color: '#c89d6a', accent: '#815b34', label: 'D' }
+      { id: 'plain', name: 'Open Ground', color: '#f3e2c3', accent: '#d3b58a', label: 'P' },
+      { id: 'forest', name: 'Forest (+2 DEF)', color: '#6f9151', accent: '#455c32', label: 'F' },
+      { id: 'hill', name: 'Hill (+2 ATK)', color: '#c7b082', accent: '#8b6c3f', label: 'H' },
+      { id: 'road', name: 'Road (Cost 1)', color: '#d0c2a2', accent: '#9e8a62', label: 'R' },
+      { id: 'swamp', name: 'Swamp (-2 ATK)', color: '#9a7855', accent: '#664b30', label: 'S' },
+      { id: 'water', name: 'Water (Impassable)', color: '#5f90c1', accent: '#2f5c82', label: 'W' }
     ];
 
     const state = {
@@ -507,7 +547,8 @@
           cell.dataset.row = r;
           cell.dataset.col = c;
           cell.tabIndex = -1;
-          cell.setAttribute('aria-label', `Row ${r + 1}, Column ${c + 1}`);
+          const axial = offsetToAxial(c, r);
+          cell.setAttribute('aria-label', `Row ${r + 1}, Column ${c + 1} (axial ${formatAxial(axial)})`);
           cell.addEventListener('pointerdown', handlePointerDown);
           cell.addEventListener('pointerenter', handlePointerEnter);
           cell.addEventListener('pointerup', handlePointerUp);
@@ -529,12 +570,13 @@
     }
 
     function setSelectedTerrain(id) {
-      state.selectedId = id;
-      state.paintId = id;
-      const activeTerrain = terrainById(id) || terrainById(state.baseTerrainId) || state.palette[0] || defaultTerrains[0];
+      const normalized = normalizeTerrainId(id, state.baseTerrainId);
+      state.selectedId = normalized;
+      state.paintId = normalized;
+      const activeTerrain = terrainById(normalized) || terrainById(state.baseTerrainId) || state.palette[0] || defaultTerrains[0];
       selectedTerrainLabel.textContent = activeTerrain ? activeTerrain.name : '—';
       for (const button of paletteEl.querySelectorAll('button')) {
-        button.classList.toggle('active', button.dataset.id === id);
+        button.classList.toggle('active', button.dataset.id === normalized);
       }
     }
 
@@ -547,7 +589,8 @@
         hoverLabel.textContent = '–';
         return;
       }
-      hoverLabel.textContent = `Row ${r + 1}, Col ${c + 1}`;
+      const axial = offsetToAxial(c, r);
+      hoverLabel.textContent = `Row ${r + 1}, Col ${c + 1} → ${formatAxial(axial)}`;
     }
 
     function handlePointerDown(event) {
@@ -591,12 +634,14 @@
 
     function applyPaint(row, col, terrainId) {
       if (row < 0 || row >= state.rows || col < 0 || col >= state.cols) return;
-      if (boardData[row][col] === terrainId) return;
-      boardData[row][col] = terrainId;
+      const normalized = normalizeTerrainId(terrainId, state.baseTerrainId);
+      if (!terrainById(normalized)) return;
+      if (boardData[row][col] === normalized) return;
+      boardData[row][col] = normalized;
       const index = row * state.cols + col;
       const cell = boardEl.children[index];
       if (cell) {
-        applyTerrainToCell(cell, terrainId);
+        applyTerrainToCell(cell, normalized);
       }
       updatePaintedCount();
     }
@@ -612,6 +657,8 @@
     }
 
     function buildPalette() {
+      state.baseTerrainId = normalizeTerrainId(state.baseTerrainId, defaultTerrains[0].id);
+      state.selectedId = normalizeTerrainId(state.selectedId, state.baseTerrainId);
       if (!state.palette.some(t => t.id === state.baseTerrainId)) {
         state.baseTerrainId = state.palette[0]?.id || defaultTerrains[0].id;
       }
@@ -688,15 +735,48 @@
       exportOutput.value = '';
     }
 
+    function buildTerrainSummary() {
+      const summary = [];
+      for (let r = 0; r < state.rows; r++) {
+        for (let c = 0; c < state.cols; c++) {
+          const id = boardData[r][c];
+          if (id === state.baseTerrainId) continue;
+          const axial = offsetToAxial(c, r);
+          summary.push({
+            id,
+            offset: { x: c, y: r },
+            axial
+          });
+        }
+      }
+      return summary;
+    }
+
     function exportMap() {
       const payload = {
-        version: 1,
-        rows: state.rows,
-        cols: state.cols,
-        cellSize: state.cellSize,
-        palette: state.palette,
+        version: 2,
+        format: 'fable-tactics-hex-offset',
+        grid: {
+          type: 'hex-offset',
+          orientation: 'pointy-top',
+          offset: 'odd-q',
+          width: state.cols,
+          height: state.rows,
+          cellSize: state.cellSize
+        },
+        palette: state.palette.map(entry => ({
+          id: entry.id,
+          name: entry.name,
+          color: entry.color,
+          accent: entry.accent,
+          label: entry.label
+        })),
         defaultTerrainId: state.baseTerrainId,
-        tiles: boardData
+        tiles: boardData.map(row => row.slice()),
+        terrain: buildTerrainSummary(),
+        metadata: {
+          exportedAt: new Date().toISOString()
+        }
       };
       const json = JSON.stringify(payload, null, 2);
       exportOutput.value = json;
@@ -717,53 +797,79 @@
 
     function loadFromJSON(json) {
       try {
-        const data = JSON.parse(json);
-        if (!Array.isArray(data.tiles) || !Array.isArray(data.palette)) {
+        const data = typeof json === 'string' ? JSON.parse(json) : json;
+        if (!data || typeof data !== 'object') {
           throw new Error('Invalid map payload.');
         }
-        state.rows = Math.max(4, Math.min(30, Number(data.rows) || data.tiles.length));
-        state.cols = Math.max(4, Math.min(30, Number(data.cols) || (data.tiles[0] ? data.tiles[0].length : 0)));
-        state.cellSize = Math.max(24, Math.min(72, Number(data.cellSize) || state.cellSize));
-        state.palette = data.palette.map(entry => ({
-          id: entry.id,
-          name: entry.name,
-          color: entry.color,
-          accent: entry.accent,
-          label: entry.label || (entry.name ? entry.name.charAt(0).toUpperCase() : '')
-        })).filter(entry => entry.id && entry.name && entry.color && entry.accent);
+        const tiles = Array.isArray(data.tiles) ? data.tiles : [];
+        if (!tiles.length || !Array.isArray(tiles[0])) {
+          throw new Error('Map JSON must include a 2D "tiles" array.');
+        }
+
+        const gridInfo = data.grid || {};
+        const derivedRows = tiles.length;
+        const derivedCols = tiles.reduce((max, row) => {
+          return Math.max(max, Array.isArray(row) ? row.length : 0);
+        }, 0);
+
+        state.rows = Math.max(4, Math.min(30, Number(gridInfo.height ?? data.rows ?? derivedRows) || derivedRows));
+        state.cols = Math.max(4, Math.min(30, Number(gridInfo.width ?? data.cols ?? derivedCols) || derivedCols));
+        const cellSize = Number(gridInfo.cellSize ?? data.cellSize);
+        if (Number.isFinite(cellSize)) {
+          state.cellSize = Math.max(24, Math.min(72, Math.round(cellSize)));
+        }
+
+        const paletteSource = Array.isArray(data.palette) ? data.palette : [];
+        const seenIds = new Set();
+        state.palette = paletteSource.map(entry => {
+          const normalizedId = normalizeTerrainId(entry.id, 'plain');
+          const name = entry.name || normalizedId.charAt(0).toUpperCase() + normalizedId.slice(1);
+          return {
+            id: normalizedId,
+            name,
+            color: entry.color || '#d4c6aa',
+            accent: entry.accent || entry.color || '#a58c63',
+            label: entry.label || (name ? name.charAt(0).toUpperCase() : '')
+          };
+        }).filter(entry => {
+          if (!entry.id || !entry.name || !entry.color || !entry.accent) return false;
+          if (seenIds.has(entry.id)) return false;
+          seenIds.add(entry.id);
+          return true;
+        });
         if (!state.palette.length) {
           state.palette = [...defaultTerrains];
         }
-        const importedBase = data.defaultTerrainId && state.palette.some(t => t.id === data.defaultTerrainId)
-          ? data.defaultTerrainId
+
+        if (!state.palette.some(t => t.id === 'plain')) {
+          state.palette.unshift({ ...defaultTerrains[0] });
+        }
+
+        const baseCandidate = normalizeTerrainId(data.defaultTerrainId, state.palette[0]?.id || defaultTerrains[0].id);
+        state.baseTerrainId = state.palette.some(t => t.id === baseCandidate)
+          ? baseCandidate
           : state.palette[0]?.id || defaultTerrains[0].id;
-        state.baseTerrainId = importedBase || defaultTerrains[0].id;
+
         if (!state.palette.some(t => t.id === state.selectedId)) {
           state.selectedId = state.baseTerrainId;
         }
+
         boardData.length = state.rows;
         for (let r = 0; r < state.rows; r++) {
+          const sourceRow = Array.isArray(tiles[r]) ? tiles[r] : [];
           boardData[r] = Array.from({ length: state.cols }, (_, c) => {
-            const row = data.tiles[r] || [];
-            const tileId = row[c] || state.baseTerrainId;
+            const tileId = normalizeTerrainId(sourceRow[c], state.baseTerrainId);
             return state.palette.some(t => t.id === tileId) ? tileId : state.baseTerrainId;
           });
         }
+
         rowsInput.value = state.rows;
         colsInput.value = state.cols;
         sizeInput.value = state.cellSize;
         setBoardDimensions();
         buildPalette();
         rebuildBoard();
-        exportOutput.value = JSON.stringify({
-          version: 1,
-          rows: state.rows,
-          cols: state.cols,
-          cellSize: state.cellSize,
-          palette: state.palette,
-          defaultTerrainId: state.baseTerrainId,
-          tiles: boardData
-        }, null, 2);
+        exportMap();
       } catch (err) {
         alert('Unable to parse map data. Please ensure the JSON structure is valid.');
         console.error(err);

--- a/combat-sim.html
+++ b/combat-sim.html
@@ -476,6 +476,9 @@
   .board-shape-opt { display:none; }
   .board-shape-opt input { width:72px; }
   .board-layout { width:100%; min-height:112px; margin-top:6px; }
+  .map-import { display:flex; flex-direction:column; gap:8px; margin-top:12px; }
+  .map-import textarea { min-height:112px; }
+  .map-import .btn-row { gap:10px; }
   .small.muted { color:var(--muted); }
 
   .dot {
@@ -847,8 +850,8 @@
 
       <div class="btn-row" style="flex-wrap:wrap; align-items:center">
         <div class="small">Grid:</div>
-        <label class="small">W <input id="gridW" type="number" min="3" max="15" value="9"></label>
-        <label class="small">H <input id="gridH" type="number" min="3" max="15" value="9"></label>
+        <label class="small">W <input id="gridW" type="number" min="3" max="30" value="9"></label>
+        <label class="small">H <input id="gridH" type="number" min="3" max="30" value="9"></label>
         <button id="applyGridBtn" class="ghost">Apply</button>
 
         <div class="small" style="margin-left:16px">Zoom:</div>
@@ -871,7 +874,17 @@
       <div class="board-shape-opt" data-shape-opt="layout">
         <label for="boardLayout" class="small">Custom Layout (# = tile, . = gap)</label>
         <textarea id="boardLayout" class="board-layout" placeholder="Example:\n..###..\n.#####.\n..###.."></textarea>
-        <div class="small muted">Rows map to offset coordinates; use <strong>#</strong> for playable hexes.</div>
+        <div class="small muted">Rows map to offset coordinates; use <strong>#</strong> for playable hexes or import a JSON layout from the Map Builder.</div>
+      </div>
+
+      <div class="map-import">
+        <label for="mapJsonInput" class="small">Import Map JSON</label>
+        <textarea id="mapJsonInput" placeholder="Paste Battlemap Builder export here…"></textarea>
+        <div class="btn-row" style="flex-wrap:wrap; gap:10px;">
+          <button id="applyMapJsonBtn" class="ghost">Apply Map JSON</button>
+          <button id="clearTerrainBtn" class="ghost">Clear Painted Terrain</button>
+        </div>
+        <div class="small muted">Terrain IDs are normalized to the core set: plain, forest, hill, road, swamp, water.</div>
       </div>
 
       <div class="btn-row">
@@ -1176,6 +1189,17 @@ function computeCustomMask(layout){
   });
   return maskFromOffsets(offsets);
 }
+function computeOffsetRectangleMask(width,height){
+  const w=Math.max(1, Math.floor(width));
+  const h=Math.max(1, Math.floor(height));
+  const offsets=[];
+  for(let y=0; y<h; y++){
+    for(let x=0; x<w; x++){
+      offsets.push({x,y});
+    }
+  }
+  return maskFromOffsets(offsets);
+}
 const BOARD_SHAPES=[
   {
     key:'hex',
@@ -1196,8 +1220,8 @@ const BOARD_SHAPES=[
     controls:['width','height'],
     defaults:{ width:9, height:9 },
     sanitize(options){
-      const width=Math.max(3, Math.min(15, Number.isFinite(options.width)?Math.floor(options.width):9));
-      const height=Math.max(3, Math.min(15, Number.isFinite(options.height)?Math.floor(options.height):9));
+      const width=Math.max(3, Math.min(30, Number.isFinite(options.width)?Math.floor(options.width):9));
+      const height=Math.max(3, Math.min(30, Number.isFinite(options.height)?Math.floor(options.height):9));
       return { width, height };
     },
     create(options){
@@ -1396,6 +1420,125 @@ const TERRAIN = {
   swamp:{cost:3, atk:-2, def:0, pass:true},
   water:{cost:999, atk:0, def:0, pass:false},
 };
+
+const BUILDER_TERRAIN_ALIASES = {
+  plain:'plain',
+  plains:'plain',
+  open:'plain',
+  forest:'forest',
+  woods:'forest',
+  cover:'forest',
+  hill:'hill',
+  stone:'hill',
+  rocky:'hill',
+  road:'road',
+  path:'road',
+  trail:'road',
+  swamp:'swamp',
+  marsh:'swamp',
+  hazard:'swamp',
+  difficult:'swamp',
+  water:'water',
+  river:'water'
+};
+
+function normalizeBuilderTerrainId(id, fallback = 'plain'){
+  if(!id) return fallback;
+  const safe = String(id).trim().toLowerCase();
+  if(!safe || safe === 'default' || safe === 'null' || safe === 'undefined' || safe === 'base'){
+    return fallback;
+  }
+  if(BUILDER_TERRAIN_ALIASES[safe]) return BUILDER_TERRAIN_ALIASES[safe];
+  if(TERRAIN[safe]) return safe;
+  return fallback;
+}
+
+function applyBuilderMap(payload){
+  let data = payload;
+  if(typeof payload === 'string'){
+    try {
+      data = JSON.parse(payload);
+    } catch (err){
+      throw new Error(`Invalid JSON: ${err.message}`);
+    }
+  }
+  if(!data || typeof data !== 'object'){
+    throw new Error('Map payload must be an object.');
+  }
+  const tiles = Array.isArray(data.tiles) ? data.tiles : [];
+  if(!tiles.length || !Array.isArray(tiles[0])){
+    throw new Error('Map JSON must include a 2D "tiles" array.');
+  }
+  const derivedRows = clamp(tiles.length, 1, 30);
+  let derivedCols = 0;
+  for(let r=0; r<derivedRows; r++){
+    const row = Array.isArray(tiles[r]) ? tiles[r] : [];
+    if(row.length > derivedCols) derivedCols = row.length;
+  }
+  derivedCols = clamp(derivedCols, 1, 30);
+
+  const gridInfo = data.grid || {};
+  const rows = clamp(Number(gridInfo.height ?? data.rows ?? derivedRows) || derivedRows, 1, 30);
+  const cols = clamp(Number(gridInfo.width ?? data.cols ?? derivedCols) || derivedCols, 1, 30);
+  const baseId = normalizeBuilderTerrainId(data.defaultTerrainId, 'plain');
+  const cellSizeRaw = Number(gridInfo.cellSize ?? data.cellSize);
+
+  const sanitizedTiles = [];
+  for(let r=0; r<rows; r++){
+    const sourceRow = Array.isArray(tiles[r]) ? tiles[r] : [];
+    sanitizedTiles[r] = [];
+    for(let c=0; c<cols; c++){
+      sanitizedTiles[r][c] = normalizeBuilderTerrainId(sourceRow[c], baseId);
+    }
+  }
+
+  const ok = setGridShape('parallelogram', { width: cols, height: rows });
+  if(!ok){
+    throw new Error('Unable to configure grid shape from imported map.');
+  }
+
+  const builderMask = computeOffsetRectangleMask(cols, rows);
+  if(!builderMask.playable || builderMask.playable.size === 0){
+    throw new Error('Imported map produced no playable cells.');
+  }
+  GRID.originX = builderMask.originX;
+  GRID.originY = builderMask.originY;
+  GRID.w = builderMask.width;
+  GRID.h = builderMask.height;
+  GRID.playable = builderMask.playable;
+
+  GRID.obstacles.clear();
+  GRID.terrain.clear();
+  const base = sanitizeTerrainId(baseId);
+  if(terrainType) terrainType.value = base;
+  for(let r=0; r<rows; r++){
+    for(let c=0; c<cols; c++){
+      const tileId = sanitizeTerrainId(sanitizedTiles[r][c], base);
+      if(tileId !== base){
+        const cellKey = key(c,r);
+        if(GRID.playable.has(cellKey)){
+          GRID.terrain.set(cellKey, tileId);
+        }
+      }
+    }
+  }
+
+  if(Number.isFinite(cellSizeRaw)){
+    const safeSize = clamp(Math.round(cellSizeRaw), 24, 96);
+    GRID.desiredCell = safeSize;
+  }
+
+  clampGridState();
+  syncGridControls();
+  boardHintDefault = 'Map imported from the Battlemap Builder. Terrain IDs were normalized for the simulator.';
+  if(BOARD_HINT) BOARD_HINT.textContent = boardHintDefault;
+  render();
+}
+
+function sanitizeTerrainId(id, fallback = 'plain'){
+  const normalized = normalizeBuilderTerrainId(id, fallback);
+  return TERRAIN[normalized] ? normalized : fallback;
+}
 function tAt(x,y){ return TERRAIN[GRID.terrain.get(key(x,y))||'plain']; }
 function tNameAt(x,y){ return GRID.terrain.get(key(x,y))||'plain'; }
 function shortName(n){ return n.replace(/\(.*?\)/,'').trim().split(' ')[0]; }
@@ -1976,6 +2119,9 @@ const boardRadiusInput = document.getElementById('boardRadius');
 const boardThicknessInput = document.getElementById('boardThickness');
 const boardLayoutInput = document.getElementById('boardLayout');
 const boardShapeOptionEls = [...document.querySelectorAll('[data-shape-opt]')];
+const mapJsonInput = document.getElementById('mapJsonInput');
+const applyMapJsonBtn = document.getElementById('applyMapJsonBtn');
+const clearTerrainBtn = document.getElementById('clearTerrainBtn');
 
 function parsePx(value){
   return typeof value === 'string' ? parseFloat(value) || 0 : 0;
@@ -2296,6 +2442,22 @@ terrainBtn?.addEventListener('click', ()=>{
   render();
 });
 clearObsBtn?.addEventListener('click', ()=>{ GRID.obstacles.clear(); render(); });
+clearTerrainBtn?.addEventListener('click', ()=>{ GRID.terrain.clear(); render(); });
+applyMapJsonBtn?.addEventListener('click', ()=>{
+  if(!mapJsonInput) return;
+  const raw = mapJsonInput.value.trim();
+  if(!raw){
+    alert('Paste map JSON before applying.');
+    return;
+  }
+  try {
+    applyBuilderMap(raw);
+    mapJsonInput.value = '';
+  } catch (err){
+    console.error(err);
+    alert('Unable to import map JSON. Check the console for details.');
+  }
+});
 
 function resetBoardState(){
   G.phase="setup";


### PR DESCRIPTION
## Summary
- mark builder exports as odd-q offset grids
- ensure combat sim recreates builder maps with an offset-based mask so every tile remains playable

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690163d17db083249cb4a32f8e525069)